### PR TITLE
Stop spectrum/meter TimelineViews from running forever in the background

### DIFF
--- a/Sources/OnlyEQ/App/AppDelegate.swift
+++ b/Sources/OnlyEQ/App/AppDelegate.swift
@@ -16,6 +16,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
         popover = NSPopover()
         popover.behavior = .transient
+        popover.delegate = self
         let hosting = NSHostingController(rootView: PopoverView().environmentObject(state))
         // Keep preferredContentSize in sync with the SwiftUI layout — without
         // this the popover mis-sizes and can render clipped past the menu bar.
@@ -147,6 +148,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     @objc private func openSettings() { WindowManager.shared.showSettings() }
 }
 
+// Closing the popover only orders its window out — the hosting controller
+// (and the SwiftUI tree inside) stays alive, so PopoverView gates its
+// spectrum TimelineView on this visibility flag to stop it from ticking
+// forever after the first show.
+extension AppDelegate: NSPopoverDelegate {
+    func popoverDidShow(_ notification: Notification) {
+        AppState.shared.popoverIsVisible = true
+    }
+
+    func popoverDidClose(_ notification: Notification) {
+        AppState.shared.popoverIsVisible = false
+    }
+}
+
 /// Owns the editor, settings, and onboarding windows.
 @MainActor
 final class WindowManager {
@@ -172,6 +187,18 @@ final class WindowManager {
             // Restore the saved frame if there is one; otherwise center.
             if !window.setFrameUsingName("EditorWindow") { window.center() }
             window.setFrameAutosaveName("EditorWindow")
+            // The window survives close (isReleasedWhenClosed = false, just
+            // ordered out), so EditorView gates its spectrum/clip TimelineViews
+            // on real visibility. Occlusion state also covers "fully covered
+            // by another window" and "on another Space", not just close.
+            NotificationCenter.default.addObserver(
+                forName: NSWindow.didChangeOcclusionStateNotification,
+                object: window, queue: .main
+            ) { note in
+                guard let window = note.object as? NSWindow else { return }
+                let visible = window.occlusionState.contains(.visible)
+                Task { @MainActor in AppState.shared.editorIsVisible = visible }
+            }
             editorWindow = window
         }
         if importing { EditorView.importRequested.send() }

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -69,6 +69,13 @@ final class AppState: ObservableObject {
     /// Set when the current preset was auto-applied by a device profile.
     @Published private(set) var presetWasAutoApplied = false
 
+    /// True only while the popover / editor window is actually on screen.
+    /// The popover's content controller and the editor window both outlive
+    /// their close (they're just ordered out), so spectrum/meter TimelineViews
+    /// gate on these to stop ticking once nothing is visible.
+    @Published var popoverIsVisible = false
+    @Published var editorIsVisible = false
+
     var effectivePreampDB: Double {
         autoPreampEnabled ? EQResponse.autoPreamp(bands: preset.bands) : preset.preampDB
     }

--- a/Sources/OnlyEQ/UI/EditorView.swift
+++ b/Sources/OnlyEQ/UI/EditorView.swift
@@ -104,6 +104,7 @@ struct EditorView: View {
                 bands: state.preset.bands,
                 preampDB: 0,
                 interactive: true,
+                showSpectrum: state.isEnabled && state.editorIsVisible,
                 showIndividualCurves: true,
                 selectedBandID: $selectedBandID,
                 onBandChange: { id, f, g in
@@ -207,18 +208,29 @@ struct EditorView: View {
         .padding(.vertical, 8)
     }
 
+    // The window survives close (only ordered out), so the meter's timer is
+    // gated on real visibility — otherwise it would tick forever after the
+    // window is first shown.
+    @ViewBuilder
     private var clipIndicator: some View {
-        TimelineView(.periodic(from: .now, by: 0.25)) { _ in
-            let peak = state.engine.processor.currentPeak
-            let db = peak > 0 ? 20 * log10(Double(peak)) : -60
-            HStack(spacing: 4) {
-                Circle()
-                    .fill(db > -0.1 ? Color.red : (db > -3 ? .orange : .green))
-                    .frame(width: 7, height: 7)
-                Text(String(format: "%.1f dBFS", max(db, -60)))
-                    .font(.system(size: 10).monospacedDigit())
-                    .foregroundStyle(.secondary)
+        if state.editorIsVisible {
+            TimelineView(.periodic(from: .now, by: 0.25)) { _ in
+                clipReadout(peak: state.engine.processor.currentPeak)
             }
+        } else {
+            clipReadout(peak: 0)
+        }
+    }
+
+    private func clipReadout(peak: Float) -> some View {
+        let db = peak > 0 ? 20 * log10(Double(peak)) : -60
+        return HStack(spacing: 4) {
+            Circle()
+                .fill(db > -0.1 ? Color.red : (db > -3 ? .orange : .green))
+                .frame(width: 7, height: 7)
+            Text(String(format: "%.1f dBFS", max(db, -60)))
+                .font(.system(size: 10).monospacedDigit())
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Sources/OnlyEQ/UI/PopoverView.swift
+++ b/Sources/OnlyEQ/UI/PopoverView.swift
@@ -163,7 +163,8 @@ struct PopoverView: View {
             VStack(spacing: 5) {
                 ZStack(alignment: .topTrailing) {
                     EQCurveView(bands: state.preset.bands, preampDB: 0,
-                                showSpectrum: state.isEnabled, spectrumStyle: .subtle)
+                                showSpectrum: state.isEnabled && state.popoverIsVisible,
+                                spectrumStyle: .subtle)
                         .frame(height: 116)
                         .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
                     Button {


### PR DESCRIPTION
I noticed OnlyEQ sits at 20-50% CPU in the background even with nothing visibly happening — no popover open, no editor window, doesn't matter whether audio is even playing. Dug into it and it comes down to `SpectrumBarsView` in `EQCurveView.swift`: a 20 Hz `TimelineView` that runs a full FFT and redraws a Canvas on every tick, and once it starts it never stops.
<img width="443" height="198" alt="Bildschirmfoto 2026-07-09 um 16 11 38" src="https://github.com/user-attachments/assets/55fd338b-c0fb-4847-b036-274f462373e9" />


The reason it never stops: the popover's `NSHostingController` is created once at launch, and `popover.performClose()` just orders the window out — it doesn't tear down the content view controller or anything inside it. The editor window is the same story (`isReleasedWhenClosed = false`). So the first time you open either one, that timer starts, and closing the window again does nothing to it — it just keeps computing spectrum bars in the background for the rest of the process's life. The editor also has a second, smaller 4 Hz timer for the clip indicator with the same problem, and its main graph view wasn't even gating `showSpectrum` on whether the EQ was enabled in the first place.

I measured this on a running instance to make sure I wasn't chasing the wrong thing:

- app idle, UI never touched: ~2.5% CPU
- open the popover once: jumps to ~20%, and closing it again doesn't bring it back down
- then open the editor window: jumps to ~50%, and closing it doesn't bring it back down either

So the fix is to track actual on-screen visibility instead of "has this ever been shown," and gate both timers on that. Popover visibility comes from `NSPopoverDelegate` (`popoverDidShow`/`popoverDidClose`). Editor window visibility comes from `NSWindow.didChangeOcclusionStateNotification`, checking `occlusionState.contains(.visible)` — a bit more correct than just listening for close, since it also catches the window being fully covered by something else or the user switching Spaces. Both flags get threaded down into `showSpectrum`, which already has an `if showSpectrum { ... }` branch in `EQCurveView.body` — SwiftUI actually unmounts that branch when it's false, so the `TimelineView` really stops scheduling rather than just skipping its draw call, and comes back cleanly the next time the window is shown.

Rebuilt and re-ran the same scenarios to confirm: idle (either never touching the UI, or opening something and closing it again) sits at 2.7-3.5% now. Opening the popover takes it to ~25% while it's open, opening the editor window on top of that takes it to ~35-40% while it's open — and closing everything brings it right back down to the 2.7-3.5% baseline instead of staying pinned at the old numbers.
