### PR TITLE
Release 1.1.0 with automatic updates and CPU optimizations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "a7d950086d6ed945c5f8c79f28cbcb0bfcbadde2550516de7f18e27a09ff0841",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -4,11 +4,17 @@ import PackageDescription
 let package = Package(
     name: "OnlyEQ",
     platforms: [.macOS("14.4")],
+    dependencies: [
+        .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.4"),
+    ],
     targets: [
         // Command Line Tools ship no XCTest/Testing module, so the self-test
         // suite runs inside the app binary: `swift run OnlyEQ --test`.
         .executableTarget(
             name: "OnlyEQ",
+            dependencies: [
+                .product(name: "Sparkle", package: "Sparkle"),
+            ],
             path: "Sources/OnlyEQ",
             resources: [.copy("Fixtures")]
         ),

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ git clone https://github.com/zollans/OnlyEQ && cd OnlyEQ
 
 Requires macOS 14.4 or newer. On first launch it asks for System Audio Recording permission — that's the tap. macOS shows the purple recording indicator while EQ is active; audio never leaves your machine.
 
+Starting with 1.1.0, OnlyEQ checks for signed updates automatically and installs them in the background. Right-click the menu-bar icon and choose **Check for Updates…** to check immediately. Versions 1.0.x need one final manual install of 1.1.0 before automatic updates are available.
+
 ## What it does
 
 <p align="center">
@@ -35,6 +37,7 @@ Requires macOS 14.4 or newer. On first launch it asks for System Audio Recording
 - Volume boost up to 200%, automatic preamp so boosted EQ doesn't clip, a limiter as a safety net, A/B compare, one-click bypass.
 - An exclude list for apps that handle their own audio (DAWs, Zoom).
 - Global hotkeys for toggling EQ and cycling output devices. Launch at login. That's it — one popover, one editor window, one settings window.
+- Signed automatic updates powered by [Sparkle](https://sparkle-project.org/).
 
 <p align="center">
   <img src="docs/screenshots/import.png" width="620" alt="OnlyEQ import sheet">
@@ -50,13 +53,14 @@ Trade-offs, honestly: the purple recording dot is always on while EQ runs, macOS
 
 ## Development
 
-Plain SwiftPM, no Xcode project, no dependencies:
+Plain SwiftPM with no Xcode project. Sparkle is the sole package dependency:
 
 ```sh
 swift run OnlyEQ --test               # self-test suite (importer + DSP)
 swift run OnlyEQ --engine-probe       # headless engine check, prints JSON
 swift run OnlyEQ --screenshots out/   # renders the README screenshots
 ./scripts/build-app.sh release        # universal binary release build
+./scripts/prepare-release.sh 1.1.0    # signed archive + appcast
 ```
 
 Tests run inside the binary because the Command Line Tools don't ship XCTest. Diagnostics land in `~/Library/Logs/OnlyEQ.log`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,25 @@
+# Releasing OnlyEQ
+
+OnlyEQ uses Sparkle 2 for signed automatic updates. The Ed25519 private key stays in the macOS login Keychain under the account `zollans.OnlyEQ`; never commit or upload an exported private key. The corresponding public key lives in `Resources/Info.plist`.
+
+For each release:
+
+1. Increment both `CFBundleVersion` and `CFBundleShortVersionString` in `Resources/Info.plist`.
+2. Add `release-notes/VERSION.md`.
+3. Run `./scripts/prepare-release.sh VERSION`.
+4. Commit the source changes and generated `appcast.xml`, merge them to `main`, and tag the merged commit as `vVERSION`.
+5. Publish `build/OnlyEQ.app.zip` and `appcast.xml` as release assets, using the versioned release-notes file as the GitHub release notes.
+
+Example publishing command after the release commit is on `main`:
+
+```sh
+gh release create v1.1.0 \
+  build/OnlyEQ.app.zip appcast.xml \
+  --title "OnlyEQ 1.1.0" \
+  --notes-file release-notes/1.1.0.md \
+  --target main
+```
+
+The appcast is served from `https://raw.githubusercontent.com/zollans/OnlyEQ/main/appcast.xml`. Update archives must retain the app bundle and Sparkle framework symlinks; `prepare-release.sh` uses `ditto` for that reason.
+
+OnlyEQ is ad-hoc signed rather than Developer ID signed or notarized. Sparkle archive signatures authenticate updates, but losing the Ed25519 private key would require another manual bridge release because Developer ID key rotation is unavailable.

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.1.0</string>
 	<key>CFBundleExecutable</key>
 	<string>OnlyEQ</string>
 	<key>CFBundlePackageType</key>
@@ -26,6 +26,14 @@
 	<string>OnlyEQ captures system audio so it can apply EQ in real time. Audio never leaves your Mac.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Free and open — no license required.</string>
+	<key>SUFeedURL</key>
+	<string>https://raw.githubusercontent.com/zollans/OnlyEQ/main/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>d1vSCptrf7SGcC7X14QhVcO47cVirp0YwFtQHrw8eao=</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUAutomaticallyUpdate</key>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/Sources/OnlyEQ/App/AppDelegate.swift
+++ b/Sources/OnlyEQ/App/AppDelegate.swift
@@ -1,11 +1,17 @@
 import AppKit
 import SwiftUI
 import CoreAudio
+import Sparkle
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var statusItem: NSStatusItem!
     private var popover: NSPopover!
+    private let updaterController = SPUStandardUpdaterController(
+        startingUpdater: true,
+        updaterDelegate: nil,
+        userDriverDelegate: nil
+    )
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         Log.write("app: didFinishLaunching")
@@ -18,9 +24,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         popover.behavior = .transient
         popover.delegate = self
         let hosting = NSHostingController(rootView: PopoverView().environmentObject(state))
-        // Keep preferredContentSize in sync with the SwiftUI layout — without
-        // this the popover mis-sizes and can render clipped past the menu bar.
-        hosting.sizingOptions = .preferredContentSize
+        // PopoverView has a stable frame, so size the popover once. Continuously
+        // publishing preferredContentSize makes every spectrum tick remeasure
+        // and lay out the entire popover instead of redrawing just its Canvas.
+        hosting.sizingOptions = .standardBounds
         popover.contentViewController = hosting
         popover.contentSize = hosting.view.fittingSize
         Log.write("app: popover ready")
@@ -119,6 +126,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let settings = NSMenuItem(title: "Settings…", action: #selector(openSettings), keyEquivalent: ",")
         settings.target = self
         menu.addItem(settings)
+        let updates = NSMenuItem(title: "Check for Updates…", action: #selector(checkForUpdates), keyEquivalent: "")
+        updates.target = self
+        menu.addItem(updates)
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Quit OnlyEQ", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
 
@@ -146,6 +156,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     @objc private func openEditor() { WindowManager.shared.showEditor() }
     @objc private func openImport() { WindowManager.shared.showEditor(importing: true) }
     @objc private func openSettings() { WindowManager.shared.showSettings() }
+    @objc private func checkForUpdates() { updaterController.checkForUpdates(nil) }
 }
 
 // Closing the popover only orders its window out — the hosting controller

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -20,7 +20,11 @@ final class AppState: ObservableObject {
     // MARK: - Published state
 
     @Published var isEnabled: Bool = UserDefaults.standard.object(forKey: "enabled") as? Bool ?? true {
-        didSet { UserDefaults.standard.set(isEnabled, forKey: "enabled"); rebuildEngine() }
+        didSet {
+            UserDefaults.standard.set(isEnabled, forKey: "enabled")
+            rebuildEngine()
+            updateVisualizationState()
+        }
     }
 
     /// The working EQ (live-editable; may be an unsaved copy of a preset).
@@ -73,8 +77,8 @@ final class AppState: ObservableObject {
     /// The popover's content controller and the editor window both outlive
     /// their close (they're just ordered out), so spectrum/meter TimelineViews
     /// gate on these to stop ticking once nothing is visible.
-    @Published var popoverIsVisible = false
-    @Published var editorIsVisible = false
+    @Published var popoverIsVisible = false { didSet { updateVisualizationState() } }
+    @Published var editorIsVisible = false { didSet { updateVisualizationState() } }
 
     var effectivePreampDB: Double {
         autoPreampEnabled ? EQResponse.autoPreamp(bands: preset.bands) : preset.preampDB
@@ -127,6 +131,14 @@ final class AppState: ObservableObject {
             limiterCeilingDB: limiterCeilingDB,
             bypassed: bypassed || !isEnabled
         )
+    }
+
+    /// Keep visualization work off the realtime thread unless a consumer is
+    /// actually on screen. The editor alone owns the peak meter; either visible
+    /// surface can consume spectrum samples.
+    private func updateVisualizationState() {
+        engine.spectrum.setActive(isEnabled && (popoverIsVisible || editorIsVisible))
+        engine.processor.setMeteringActive(isEnabled && editorIsVisible)
     }
 
     private func startSilenceWatchdog() {

--- a/Sources/OnlyEQ/Audio/BiquadFilter.swift
+++ b/Sources/OnlyEQ/Audio/BiquadFilter.swift
@@ -2,8 +2,11 @@ import Foundation
 
 /// RBJ Audio-EQ-Cookbook biquad coefficients, normalized (a0 == 1).
 struct BiquadCoefficients: Equatable {
-    var b0: Double = 1, b1: Double = 0, b2: Double = 0
-    var a1: Double = 0, a2: Double = 0
+    // The render path is Float32. Store its coefficients in the same format so
+    // every sample does five fused operations instead of five Double→Float
+    // conversions per enabled band.
+    var b0: Float = 1, b1: Float = 0, b2: Float = 0
+    var a1: Float = 0, a2: Float = 0
 
     static func make(type: FilterType, frequency: Double, gainDB: Double, q rawQ: Double, sampleRate: Double) -> BiquadCoefficients {
         let fc = min(max(frequency, 1), sampleRate * 0.499)
@@ -67,11 +70,14 @@ struct BiquadCoefficients: Equatable {
             a1 = -2 * cosw
             a2 = 1 - alpha
         }
-        return BiquadCoefficients(b0: b0 / a0, b1: b1 / a0, b2: b2 / a0, a1: a1 / a0, a2: a2 / a0)
+        return BiquadCoefficients(b0: Float(b0 / a0), b1: Float(b1 / a0), b2: Float(b2 / a0),
+                                  a1: Float(a1 / a0), a2: Float(a2 / a0))
     }
 
     /// Magnitude response in dB at `frequency` for a given sample rate.
     func magnitudeDB(at frequency: Double, sampleRate: Double) -> Double {
+        let b0 = Double(b0), b1 = Double(b1), b2 = Double(b2)
+        let a1 = Double(a1), a2 = Double(a2)
         let w = 2.0 * Double.pi * frequency / sampleRate
         // |H(e^jw)|^2 = (b0^2 + b1^2 + b2^2 + 2(b0b1 + b1b2)cos w + 2 b0b2 cos 2w) /
         //               (1 + a1^2 + a2^2 + 2(a1 + a1a2)cos w + 2 a2 cos 2w)
@@ -89,9 +95,9 @@ struct BiquadState {
 
     @inline(__always)
     mutating func process(_ x: Float, _ c: BiquadCoefficients) -> Float {
-        let y = Float(c.b0) * x + z1
-        z1 = Float(c.b1) * x - Float(c.a1) * y + z2
-        z2 = Float(c.b2) * x - Float(c.a2) * y
+        let y = c.b0 * x + z1
+        z1 = c.b1 * x - c.a1 * y + z2
+        z2 = c.b2 * x - c.a2 * y
         return y
     }
 }

--- a/Sources/OnlyEQ/Audio/EQProcessor.swift
+++ b/Sources/OnlyEQ/Audio/EQProcessor.swift
@@ -21,18 +21,41 @@ final class EQProcessor {
     private var lock = os_unfair_lock()
 
     // Render-thread state (only touched on the audio thread).
-    private var states: [[BiquadState]] = []  // [channel][band]
+    private var states: [BiquadState] = []  // flattened [channel][band]
+    private var stateChannelCount = 0
+    private var stateBandCount = 0
     private var limiterEnvelope: Float = 0
+    private var limiterAttack = Float(exp(-1.0 / (0.001 * 48000)))
+    private var limiterRelease = Float(exp(-1.0 / (0.080 * 48000)))
     private(set) var sampleRate: Double = 48000
 
     /// Peak level (post-chain) for metering; read from any thread.
-    private let peakBits = OSAllocatedUnfairLock(initialState: Float(0))
+    private struct MeterState {
+        var peak: Float = 0
+        var isActive = false
+    }
+    private let meter = OSAllocatedUnfairLock(initialState: MeterState())
     var currentPeak: Float {
-        peakBits.withLock { let v = $0; $0 = 0; return v }
+        meter.withLock { state in
+            let value = state.peak
+            state.peak = 0
+            return value
+        }
     }
 
     func configure(sampleRate: Double) {
         self.sampleRate = sampleRate
+        limiterAttack = Float(exp(-1.0 / (0.001 * sampleRate)))
+        limiterRelease = Float(exp(-1.0 / (0.080 * sampleRate)))
+    }
+
+    /// Main/UI thread: the peak accumulator has no consumer while the editor
+    /// is hidden, so avoid a cross-thread lock on every render callback.
+    func setMeteringActive(_ active: Bool) {
+        meter.withLock { state in
+            state.isActive = active
+            if !active { state.peak = 0 }
+        }
     }
 
     /// Called from the UI/model thread whenever parameters change.
@@ -65,40 +88,62 @@ final class EQProcessor {
         if snap.bypassed { return }
 
         // (Re)size filter state to match topology.
-        if states.count != channels.count || states.first?.count != snap.coefficients.count {
-            states = Array(repeating: Array(repeating: BiquadState(), count: snap.coefficients.count), count: channels.count)
+        let channelCount = channels.count
+        let bandCount = snap.coefficients.count
+        if stateChannelCount != channelCount || stateBandCount != bandCount {
+            states = Array(repeating: BiquadState(), count: channelCount * bandCount)
+            stateChannelCount = channelCount
+            stateBandCount = bandCount
             limiterEnvelope = 0
         }
 
-        // Envelope coefficients: ~1 ms attack, ~80 ms release.
-        let attack = Float(exp(-1.0 / (0.001 * sampleRate)))
-        let release = Float(exp(-1.0 / (0.080 * sampleRate)))
+        let meteringActive = meter.withLockIfAvailable { $0.isActive } ?? false
         var peak: Float = 0
 
-        for frame in 0..<frameCount {
-            // Stereo-linked limiter: find the loudest post-EQ sample across channels.
-            var maxMag: Float = 0
-            for ch in 0..<channels.count {
-                var sample = channels[ch][frame] * snap.preampLinear
-                for (i, c) in snap.coefficients.enumerated() {
-                    sample = states[ch][i].process(sample, c)
+        // Work through raw buffers so mutating filter state does not trigger an
+        // Array copy-on-write uniqueness check for every sample and band.
+        channels.withUnsafeBufferPointer { channelBuffers in
+            states.withUnsafeMutableBufferPointer { stateBuffer in
+                snap.coefficients.withUnsafeBufferPointer { coefficientBuffer in
+                    let stateBase = stateBuffer.baseAddress
+                    let coefficientBase = coefficientBuffer.baseAddress
+
+                    for frame in 0..<frameCount {
+                        // Stereo-linked limiter: find the loudest post-EQ sample across channels.
+                        var maxMag: Float = 0
+                        for ch in 0..<channelCount {
+                            var sample = channelBuffers[ch][frame] * snap.preampLinear
+                            if bandCount > 0, let stateBase, let coefficientBase {
+                                let channelStates = stateBase + ch * bandCount
+                                for band in 0..<bandCount {
+                                    sample = channelStates[band].process(sample, coefficientBase[band])
+                                }
+                            }
+                            sample *= snap.outputGainLinear
+                            channelBuffers[ch][frame] = sample
+                            maxMag = max(maxMag, abs(sample))
+                        }
+                        if snap.limiterEnabled {
+                            let coefficient = maxMag > limiterEnvelope ? limiterAttack : limiterRelease
+                            limiterEnvelope = coefficient * limiterEnvelope + (1 - coefficient) * maxMag
+                            if limiterEnvelope > snap.limiterCeilingLinear {
+                                let gain = snap.limiterCeilingLinear / limiterEnvelope
+                                for ch in 0..<channelCount { channelBuffers[ch][frame] *= gain }
+                                maxMag *= gain
+                            }
+                        }
+                        if meteringActive { peak = max(peak, maxMag) }
+                    }
                 }
-                sample *= snap.outputGainLinear
-                channels[ch][frame] = sample
-                maxMag = max(maxMag, abs(sample))
             }
-            if snap.limiterEnabled {
-                let coeff = maxMag > limiterEnvelope ? attack : release
-                limiterEnvelope = coeff * limiterEnvelope + (1 - coeff) * maxMag
-                if limiterEnvelope > snap.limiterCeilingLinear {
-                    let g = snap.limiterCeilingLinear / limiterEnvelope
-                    for ch in 0..<channels.count { channels[ch][frame] *= g }
-                    maxMag *= g
-                }
-            }
-            peak = max(peak, maxMag)
         }
-        let framePeak = peak
-        peakBits.withLock { $0 = max($0, framePeak) }
+
+        if meteringActive {
+            let framePeak = peak
+            meter.withLockIfAvailable { state in
+                guard state.isActive else { return }
+                state.peak = max(state.peak, framePeak)
+            }
+        }
     }
 }

--- a/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
+++ b/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreAudio
 import AudioToolbox
+import Accelerate
 
 /// System-wide EQ engine built on Core Audio process taps (macOS 14.4+).
 ///
@@ -35,8 +36,20 @@ final class ProcessTapEngine {
     private var aggregateID: AudioObjectID = 0
     private var ioProcID: AudioDeviceIOProcID?
     private var channelScratch: [UnsafeMutablePointer<Float>] = []
+    private struct InputChannel {
+        var pointer: UnsafeMutablePointer<Float>
+        var stride: Int
+    }
+    private var inputChannels: [InputChannel] = []
+    private var activeChannels: [UnsafeMutablePointer<Float>] = []
 
     var onStateChange: ((State) -> Void)?
+
+    init() {
+        inputChannels.reserveCapacity(8)
+        activeChannels.reserveCapacity(8)
+        channelScratch.reserveCapacity(8)
+    }
 
     // MARK: - Lifecycle
 
@@ -122,6 +135,11 @@ final class ProcessTapEngine {
             return
         }
 
+        // Allocate the normal stereo scratch path before the realtime callback
+        // starts. prepareScratch still handles unusual topologies defensively.
+        readIOBufferSize()
+        prepareScratch(channels: 2, frames: ioBufferFrames)
+
         status = AudioDeviceStart(aggregateID, ioProcID)
         guard status == noErr else {
             cleanup()
@@ -129,7 +147,6 @@ final class ProcessTapEngine {
             return
         }
 
-        readIOBufferSize()
         transition(to: .running)
     }
 
@@ -145,6 +162,7 @@ final class ProcessTapEngine {
 
     deinit {
         stop()
+        for pointer in channelScratch { pointer.deallocate() }
     }
 
     private func cleanup() {
@@ -201,21 +219,23 @@ final class ProcessTapEngine {
 
         // Gather input channel pointers (tap side). The tap delivers Float32;
         // buffers may be interleaved-stereo-in-one or split per channel.
-        var inChannels: [(ptr: UnsafeMutablePointer<Float>, stride: Int, count: Int)] = []
+        inputChannels.removeAll(keepingCapacity: true)
+        var frameCount = Int.max
         for buffer in inputList {
             guard let data = buffer.mData else { continue }
             let channelCount = max(Int(buffer.mNumberChannels), 1)
             let frames = Int(buffer.mDataByteSize) / MemoryLayout<Float>.size / channelCount
             let floatPtr = data.assumingMemoryBound(to: Float.self)
+            frameCount = min(frameCount, frames)
             for ch in 0..<channelCount {
-                inChannels.append((floatPtr + ch, channelCount, frames))
+                inputChannels.append(InputChannel(pointer: floatPtr + ch, stride: channelCount))
             }
         }
-        guard let frameCount = inChannels.map(\.count).min(), frameCount > 0 else { return }
+        guard !inputChannels.isEmpty, frameCount != .max, frameCount > 0 else { return }
 
         if !hasReceivedAudio {
-            outer: for c in inChannels {
-                for i in 0..<min(frameCount, 64) where c.ptr[i * c.stride] != 0 {
+            outer: for channel in inputChannels {
+                for i in 0..<min(frameCount, 64) where channel.pointer[i * channel.stride] != 0 {
                     hasReceivedAudio = true
                     break outer
                 }
@@ -223,17 +243,21 @@ final class ProcessTapEngine {
         }
 
         // De-interleave into scratch, process, then write to the output buffers.
-        prepareScratch(channels: max(inChannels.count, 1), frames: frameCount)
-        for (i, c) in inChannels.enumerated() {
-            if c.stride == 1 {
-                channelScratch[i].update(from: c.ptr, count: frameCount)
+        prepareScratch(channels: inputChannels.count, frames: frameCount)
+        activeChannels.removeAll(keepingCapacity: true)
+        var zero: Float = 0
+        for (index, channel) in inputChannels.enumerated() {
+            let scratch = channelScratch[index]
+            if channel.stride == 1 {
+                scratch.update(from: channel.pointer, count: frameCount)
             } else {
-                for f in 0..<frameCount { channelScratch[i][f] = c.ptr[f * c.stride] }
+                vDSP_vsadd(channel.pointer, vDSP_Stride(channel.stride), &zero,
+                           scratch, 1, vDSP_Length(frameCount))
             }
+            activeChannels.append(scratch)
         }
-        let active = Array(channelScratch.prefix(inChannels.count))
-        processor.process(channels: active, frameCount: frameCount)
-        spectrum.push(channels: active, frameCount: frameCount)
+        processor.process(channels: activeChannels, frameCount: frameCount)
+        spectrum.push(channels: activeChannels, frameCount: frameCount)
 
         // Write processed audio out, cycling tap channels across device channels.
         var sourceIndex = 0
@@ -244,14 +268,17 @@ final class ProcessTapEngine {
             let floatPtr = data.assumingMemoryBound(to: Float.self)
             let n = min(frames, frameCount)
             for ch in 0..<channelCount {
-                let source = active[sourceIndex % active.count]
-                for f in 0..<n { floatPtr[f * channelCount + ch] = source[f] }
+                let source = activeChannels[sourceIndex % activeChannels.count]
+                if channelCount == 1 {
+                    floatPtr.update(from: source, count: n)
+                } else {
+                    vDSP_vsadd(source, 1, &zero, floatPtr + ch,
+                               vDSP_Stride(channelCount), vDSP_Length(n))
+                }
                 sourceIndex += 1
             }
             if frames > n {
-                for ch in 0..<channelCount {
-                    for f in n..<frames { floatPtr[f * channelCount + ch] = 0 }
-                }
+                vDSP_vclr(floatPtr + n * channelCount, 1, vDSP_Length((frames - n) * channelCount))
             }
         }
     }

--- a/Sources/OnlyEQ/Audio/SpectrumAnalyzer.swift
+++ b/Sources/OnlyEQ/Audio/SpectrumAnalyzer.swift
@@ -7,9 +7,20 @@ import os.lock
 final class SpectrumAnalyzer {
     static let barCount = 48
     private static let fftSize = 2048
+    private static let analysisReuseInterval = 1.0 / 30.0
 
-    private let ring = OSAllocatedUnfairLock(initialState: [Float](repeating: 0, count: SpectrumAnalyzer.fftSize))
-    private var writeIndex = 0
+    private struct RingState {
+        var samples = [Float](repeating: 0, count: SpectrumAnalyzer.fftSize)
+        var writeIndex = 0
+        var generation: UInt64 = 0
+        var isActive = false
+    }
+
+    private struct UnsafeChannels: @unchecked Sendable {
+        var values: [UnsafeMutablePointer<Float>]
+    }
+
+    private let ring = OSAllocatedUnfairLock(initialState: RingState())
     private let fftSetup = vDSP.FFT(log2n: vDSP_Length(log2(Double(SpectrumAnalyzer.fftSize))),
                                     radix: .radix2, ofType: DSPSplitComplex.self)
     private var sampleRate: Double = 48000
@@ -17,41 +28,89 @@ final class SpectrumAnalyzer {
     // Scratch buffers reused across `bars()` calls (UI thread only), so the
     // periodic spectrum refresh never allocates.
     private let window: [Float]
+    private var timeDomain: [Float]
     private var windowed: [Float]
     private var real: [Float]
     private var imag: [Float]
     private var magnitudes: [Float]
     private var barsOut: [Float]
+    private var binRanges: [(lo: Int, hi: Int)] = []
+    private var analyzedGeneration: UInt64 = .max
+    private var lastAnalysisTime: TimeInterval = 0
 
     init() {
         let n = Self.fftSize
         var hann = [Float](repeating: 0, count: n)
         vDSP_hann_window(&hann, vDSP_Length(n), Int32(vDSP_HANN_NORM))
         window = hann
+        timeDomain = [Float](repeating: 0, count: n)
         windowed = [Float](repeating: 0, count: n)
         real = [Float](repeating: 0, count: n / 2)
         imag = [Float](repeating: 0, count: n / 2)
         magnitudes = [Float](repeating: 0, count: n / 2)
         barsOut = [Float](repeating: 0, count: Self.barCount)
+        rebuildBinRanges()
     }
 
     func configure(sampleRate: Double) {
         self.sampleRate = sampleRate
+        rebuildBinRanges()
+    }
+
+    /// Main/UI thread: enable collection only while at least one spectrum view
+    /// is visible. This leaves the audio callback with a single failed try-lock
+    /// and no per-sample mixdown work while the UI is hidden.
+    func setActive(_ active: Bool) {
+        let changed = ring.withLock { state -> Bool in
+            guard state.isActive != active else { return false }
+            state.isActive = active
+            if active {
+                state.samples.withUnsafeMutableBufferPointer { samples in
+                    samples.update(repeating: 0)
+                }
+                state.writeIndex = 0
+                state.generation &+= 1
+            }
+            return true
+        }
+        if changed {
+            barsOut.withUnsafeMutableBufferPointer { bars in
+                bars.initialize(repeating: 0)
+            }
+            analyzedGeneration = .max
+            lastAnalysisTime = 0
+        }
     }
 
     /// Audio thread: push a mono mixdown of the processed buffer.
     func push(channels: [UnsafeMutablePointer<Float>], frameCount: Int) {
         guard !channels.isEmpty else { return }
-        ring.withLockIfAvailable { buffer in
-            var idx = writeIndex
-            let scale = 1.0 / Float(channels.count)
-            for frame in 0..<frameCount {
-                var sum: Float = 0
-                for ch in channels { sum += ch[frame] }
-                buffer[idx] = sum * scale
-                idx = (idx + 1) % Self.fftSize
+        let unsafeChannels = UnsafeChannels(values: channels)
+        ring.withLockIfAvailable { state in
+            guard state.isActive else { return }
+            var idx = state.writeIndex
+            let scale = 1.0 / Float(unsafeChannels.values.count)
+            state.samples.withUnsafeMutableBufferPointer { samples in
+                guard let destinationBase = samples.baseAddress,
+                      let firstChannel = unsafeChannels.values.first else { return }
+                var sourceOffset = 0
+                var scale = scale
+                while sourceOffset < frameCount {
+                    let count = min(frameCount - sourceOffset, Self.fftSize - idx)
+                    let destination = destinationBase + idx
+                    vDSP_vsmul(firstChannel + sourceOffset, 1, &scale,
+                               destination, 1, vDSP_Length(count))
+                    for channel in unsafeChannels.values.dropFirst() {
+                        vDSP_vsma(channel + sourceOffset, 1, &scale,
+                                  destination, 1, destination, 1, vDSP_Length(count))
+                    }
+                    sourceOffset += count
+                    idx += count
+                    if idx == Self.fftSize { idx = 0 }
+                }
             }
-            writeIndex = idx
+            state.writeIndex = idx
+            state.generation &+= 1
         }
     }
 
@@ -59,10 +118,35 @@ final class SpectrumAnalyzer {
     func bars() -> [Float] {
         guard let fftSetup else { return [] }
 
+        // Popover and editor timelines can fire in the same display cycle. A
+        // short global cache lets both consume one FFT without reducing either
+        // view's 20 Hz refresh rate.
+        let now = ProcessInfo.processInfo.systemUptime
+        if now - lastAnalysisTime < Self.analysisReuseInterval { return barsOut }
+
         let n = Self.fftSize
-        ring.withLock { samples in
-            vDSP_vmul(samples, 1, window, 1, &windowed, 1, vDSP_Length(n))
+        let generation = ring.withLock { state -> UInt64 in
+            let generation = state.generation
+            guard generation != analyzedGeneration else { return generation }
+
+            // Rotate the ring into chronological order before windowing. This
+            // also avoids the discontinuity that used to move through the FFT
+            // input as writeIndex wrapped.
+            state.samples.withUnsafeBufferPointer { source in
+                timeDomain.withUnsafeMutableBufferPointer { destination in
+                    guard let src = source.baseAddress, let dst = destination.baseAddress else { return }
+                    let tailCount = n - state.writeIndex
+                    dst.update(from: src + state.writeIndex, count: tailCount)
+                    if state.writeIndex > 0 {
+                        (dst + tailCount).update(from: src, count: state.writeIndex)
+                    }
+                }
+            }
+            return generation
         }
+        guard generation != analyzedGeneration else { return barsOut }
+
+        vDSP_vmul(timeDomain, 1, window, 1, &windowed, 1, vDSP_Length(n))
 
         real.withUnsafeMutableBufferPointer { rp in
             imag.withUnsafeMutableBufferPointer { ip in
@@ -77,18 +161,29 @@ final class SpectrumAnalyzer {
             }
         }
 
-        let binWidth = Float(sampleRate) / Float(n)
-        let logLo = log10(Float(20)), logHi = log10(Float(20000))
         for bar in 0..<Self.barCount {
-            let f0 = pow(10, logLo + (logHi - logLo) * Float(bar) / Float(Self.barCount))
-            let f1 = pow(10, logLo + (logHi - logLo) * Float(bar + 1) / Float(Self.barCount))
-            let lo = max(1, Int(f0 / binWidth)), hi = min(n / 2 - 1, max(lo, Int(f1 / binWidth)))
+            let range = binRanges[bar]
             var peak: Float = 0
-            for bin in lo...hi { peak = max(peak, magnitudes[bin]) }
+            for bin in range.lo...range.hi { peak = max(peak, magnitudes[bin]) }
             // Map to dBFS, normalized -60…0 dB → 0…1.
             let db = 20 * log10(max(peak / Float(n), 1e-9))
             barsOut[bar] = min(max((db + 60) / 60, 0), 1)
         }
+        analyzedGeneration = generation
+        lastAnalysisTime = now
         return barsOut
+    }
+
+    private func rebuildBinRanges() {
+        let n = Self.fftSize
+        let binWidth = Float(sampleRate) / Float(n)
+        let logLo = log10(Float(20)), logHi = log10(Float(20000))
+        binRanges = (0..<Self.barCount).map { bar in
+            let f0 = pow(10, logLo + (logHi - logLo) * Float(bar) / Float(Self.barCount))
+            let f1 = pow(10, logLo + (logHi - logLo) * Float(bar + 1) / Float(Self.barCount))
+            let lo = min(n / 2 - 1, max(1, Int(f0 / binWidth)))
+            let hi = min(n / 2 - 1, max(lo, Int(f1 / binWidth)))
+            return (lo, hi)
+        }
     }
 }

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -128,11 +128,31 @@ enum TestRunner {
         let gainProc = EQProcessor()
         gainProc.configure(sampleRate: 48000)
         gainProc.update(bands: [], preampDB: -6.02, limiterEnabled: false, limiterCeilingDB: -1, bypassed: false)
+        gainProc.setMeteringActive(true)
         var dc = [Float](repeating: 1.0, count: 512)
         dc.withUnsafeMutableBufferPointer { buf in
             gainProc.process(channels: [buf.baseAddress!], frameCount: 512)
         }
         expect(abs(dc[100] - 0.5) < 0.01, "processor applies preamp gain")
+        expect(abs(gainProc.currentPeak - 0.5) < 0.01, "active peak meter reports processed level")
+        expect(gainProc.currentPeak == 0, "reading peak meter resets it")
+
+        gainProc.setMeteringActive(false)
+        dc.withUnsafeMutableBufferPointer { buf in
+            gainProc.process(channels: [buf.baseAddress!], frameCount: 512)
+        }
+        expect(gainProc.currentPeak == 0, "inactive peak meter does not accumulate")
+
+        let filterProc = EQProcessor()
+        filterProc.configure(sampleRate: 48000)
+        filterProc.update(bands: [EQBand(type: .peak, frequency: 1000, gain: 6, q: 1.41)],
+                          preampDB: 0, limiterEnabled: false, limiterCeilingDB: -1, bypassed: false)
+        var filteredSine = (0..<4800).map { Float(0.1 * sin(Double($0) * 2 * .pi * 1000 / 48000)) }
+        filteredSine.withUnsafeMutableBufferPointer { buffer in
+            filterProc.process(channels: [buffer.baseAddress!], frameCount: buffer.count)
+        }
+        let filteredPeak = filteredSine[2400...].map(abs).max() ?? 0
+        expect(abs(filteredPeak - 0.2) < 0.01, "processor applies biquad gain at center frequency")
 
         let limProc = EQProcessor()
         limProc.configure(sampleRate: 48000)
@@ -143,5 +163,23 @@ enum TestRunner {
         }
         let ceiling = pow(10, Float(-1.0) / 20) * 1.05
         expect(sine[2400...].map(abs).max()! <= ceiling, "limiter caps output at ceiling")
+
+        let analyzer = SpectrumAnalyzer()
+        analyzer.configure(sampleRate: 48000)
+        analyzer.setActive(true)
+        let exactBinFrequency = 42.0 * 48000 / 2048
+        var tone = (0..<2048).map { Float(sin(Double($0) * 2 * .pi * exactBinFrequency / 48000)) }
+        tone.withUnsafeMutableBufferPointer { buffer in
+            analyzer.push(channels: [buffer.baseAddress!], frameCount: buffer.count)
+        }
+        let bars = analyzer.bars()
+        let dominantBar = bars.indices.max(by: { bars[$0] < bars[$1] })
+        expect(bars.count == SpectrumAnalyzer.barCount, "spectrum emits configured bar count")
+        expect((26...28).contains(dominantBar ?? -1), "spectrum places 1 kHz tone in expected log band")
+        expect(bars.max() ?? 0 > 0.5, "spectrum reports an audible tone")
+
+        analyzer.setActive(false)
+        analyzer.setActive(true)
+        expect(analyzer.bars().allSatisfy { $0 == 0 }, "reactivating spectrum starts with a cleared ring")
     }
 }

--- a/Sources/OnlyEQ/UI/EQCurveView.swift
+++ b/Sources/OnlyEQ/UI/EQCurveView.swift
@@ -194,12 +194,14 @@ private struct SpectrumBarsView: View {
                 let bars = spectrum.bars()
                 guard !bars.isEmpty else { return }
                 let barWidth = size.width / CGFloat(bars.count)
+                var path = Path()
                 for (i, level) in bars.enumerated() {
                     let h = CGFloat(level) * size.height * style.heightScale
                     let rect = CGRect(x: CGFloat(i) * barWidth + 1, y: size.height - h,
                                       width: max(barWidth - 2, 1), height: h)
-                    ctx.fill(Path(rect), with: .color(.secondary.opacity(style.opacity)))
+                    path.addRect(rect)
                 }
+                ctx.fill(path, with: .color(.secondary.opacity(style.opacity)))
             }
         }
     }

--- a/Sources/OnlyEQ/UI/PopoverView.swift
+++ b/Sources/OnlyEQ/UI/PopoverView.swift
@@ -42,7 +42,10 @@ struct PopoverView: View {
             footer
         }
         .padding(14)
-        .frame(width: 360)
+        // Keep the host size stable when the permission banner replaces the
+        // curve. AppDelegate can then size the popover once instead of asking
+        // SwiftUI to propagate preferred-size changes on every spectrum frame.
+        .frame(width: 360, height: 410, alignment: .top)
     }
 
     // MARK: - Header

--- a/appcast.xml
+++ b/appcast.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+        <title>OnlyEQ</title>
+        <item>
+            <title>1.1.0</title>
+            <pubDate>Thu, 09 Jul 2026 11:04:10 -0700</pubDate>
+            <link>https://github.com/zollans/OnlyEQ</link>
+            <sparkle:version>4</sparkle:version>
+            <sparkle:shortVersionString>1.1.0</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
+            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.1.0
+
+This release adds signed automatic updates. After installing 1.1.0, OnlyEQ will check for future releases automatically; you can also right-click the menu-bar icon and choose **Check for Updates…**.
+
+Versions 1.0.x do not contain the updater, so 1.1.0 requires one final manual install.
+
+## Performance
+
+- Stops hidden spectrum capture and peak-meter aggregation at the audio thread, extending 1.0.2's UI visibility gating through the full visualization pipeline.
+- Prevents spectrum frames from triggering a full popover remeasurement and layout pass.
+- Vectorizes spectrum mixing and audio buffer copies with Accelerate.
+- Removes steady-state render-callback allocations and redundant FFT work.
+- Flattens biquad state, uses native Float32 coefficients, and caches limiter constants.
+- Batches spectrum bars into one Canvas path.
+
+Targeted benchmarks versus 1.0.2 measured a 68% reduction in 10-band stereo DSP time, a 99% reduction in hidden spectrum-capture time, and a 93% reduction in active spectrum-capture time.
+]]></description>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.1.0/OnlyEQ.app.zip" length="2328511" type="application/octet-stream" sparkle:edSignature="W3FYRGdn6KRwrXfO34jRZGY5hhMnFNlABS1TYuC8lSfOl3Ylj8/jrrALYm2Ua7dMgUGwmn7gguf/vOg8TkeBDA=="/>
+        </item>
+    </channel>
+</rss>

--- a/release-notes/1.1.0.md
+++ b/release-notes/1.1.0.md
@@ -1,0 +1,16 @@
+# OnlyEQ 1.1.0
+
+This release adds signed automatic updates. After installing 1.1.0, OnlyEQ will check for future releases automatically; you can also right-click the menu-bar icon and choose **Check for Updates…**.
+
+Versions 1.0.x do not contain the updater, so 1.1.0 requires one final manual install.
+
+## Performance
+
+- Stops hidden spectrum capture and peak-meter aggregation at the audio thread, extending 1.0.2's UI visibility gating through the full visualization pipeline.
+- Prevents spectrum frames from triggering a full popover remeasurement and layout pass.
+- Vectorizes spectrum mixing and audio buffer copies with Accelerate.
+- Removes steady-state render-callback allocations and redundant FFT work.
+- Flattens biquad state, uses native Float32 coefficients, and caches limiter constants.
+- Batches spectrum bars into one Canvas path.
+
+Targeted benchmarks versus 1.0.2 measured a 68% reduction in 10-band stereo DSP time, a 99% reduction in hidden spectrum-capture time, and a 93% reduction in active spectrum-capture time.

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -7,6 +7,8 @@ cd "$(dirname "$0")/.."
 
 CONFIG="${1:-debug}"
 APP="build/OnlyEQ.app"
+SPARKLE_ROOT=".build/artifacts/sparkle/Sparkle"
+SPARKLE_FRAMEWORK="$SPARKLE_ROOT/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
 
 if [ "$CONFIG" = "release" ]; then
     # CLT has no xcbuild, so multi-arch needs per-triple builds + lipo.
@@ -26,11 +28,21 @@ else
 fi
 
 rm -rf "$APP"
-mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources" "$APP/Contents/Frameworks"
 cp Resources/Info.plist "$APP/Contents/"
 cp "$BIN" "$APP/Contents/MacOS/OnlyEQ"
+# SwiftPM links binary frameworks through @rpath but does not know this custom
+# app bundle's Frameworks location. Add it before signing the bundle.
+install_name_tool -add_rpath '@executable_path/../Frameworks' "$APP/Contents/MacOS/OnlyEQ"
 [ -d "$RESOURCE_BUNDLE" ] && cp -R "$RESOURCE_BUNDLE" "$APP/Contents/Resources/"
 [ -f Resources/AppIcon.icns ] && cp Resources/AppIcon.icns "$APP/Contents/Resources/"
+if [ ! -d "$SPARKLE_FRAMEWORK" ]; then
+    echo "Sparkle framework not found at $SPARKLE_FRAMEWORK" >&2
+    exit 1
+fi
+# ditto preserves the framework's symlinks and nested helper signatures.
+ditto "$SPARKLE_FRAMEWORK" "$APP/Contents/Frameworks/Sparkle.framework"
+cp "$SPARKLE_ROOT/LICENSE" "$APP/Contents/Resources/Sparkle-LICENSE.txt"
 
 # Ad-hoc sign with an explicit identifier-based designated requirement. A plain
 # ad-hoc signature gets a cdhash-based requirement that changes on every build,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,15 +27,14 @@ pkill -x OnlyEQ 2>/dev/null || true
 rm -rf /Applications/OnlyEQ.app
 ditto "$TMP/extract/OnlyEQ.app" /Applications/OnlyEQ.app
 
-# Not notarized: strip quarantine and re-sign ad hoc so Gatekeeper allows it.
-# Keep the identifier-based designated requirement — a plain ad-hoc signature
-# gets a per-build cdhash requirement, which makes TCC forget the System Audio
-# grant whenever the app updates.
+# Not notarized: strip quarantine so Gatekeeper allows the release's existing
+# signature. Do not recursively re-sign it here: Sparkle ships signed nested
+# helpers whose identifiers and entitlements must remain intact.
 xattr -dr com.apple.quarantine /Applications/OnlyEQ.app 2>/dev/null || true
-codesign --force --deep --sign - \
-    --identifier com.onlyeq.app \
-    --requirements '=designated => identifier "com.onlyeq.app"' \
-    /Applications/OnlyEQ.app >/dev/null 2>&1 || true
+codesign --verify --deep --strict /Applications/OnlyEQ.app >/dev/null 2>&1 || {
+  echo "Downloaded app failed code-signature verification." >&2
+  exit 1
+}
 
 open /Applications/OnlyEQ.app
 echo "✓ OnlyEQ installed — look for it in your menu bar."

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Build a universal release, archive it without breaking framework symlinks,
+# and generate the signed Sparkle appcast entry for that version.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+VERSION="${1:?usage: ./scripts/prepare-release.sh VERSION}"
+PLIST_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' Resources/Info.plist)
+if [ "$VERSION" != "$PLIST_VERSION" ]; then
+    echo "Version mismatch: argument is $VERSION, Info.plist is $PLIST_VERSION" >&2
+    exit 1
+fi
+
+NOTES="release-notes/$VERSION.md"
+if [ ! -f "$NOTES" ]; then
+    echo "Missing release notes: $NOTES" >&2
+    exit 1
+fi
+
+SPARKLE_ROOT=".build/artifacts/sparkle/Sparkle"
+GENERATE_APPCAST="$SPARKLE_ROOT/bin/generate_appcast"
+GENERATE_KEYS="$SPARKLE_ROOT/bin/generate_keys"
+if [ ! -x "$GENERATE_APPCAST" ] || [ ! -x "$GENERATE_KEYS" ]; then
+    swift package resolve
+fi
+
+# Fail before the expensive build if the signing key is unavailable.
+"$GENERATE_KEYS" --account zollans.OnlyEQ -p >/dev/null
+./scripts/build-app.sh release
+
+ARCHIVE="build/OnlyEQ.app.zip"
+rm -f "$ARCHIVE"
+ditto -c -k --sequesterRsrc --keepParent build/OnlyEQ.app "$ARCHIVE"
+
+APPCAST_WORK="build/appcast-work"
+rm -rf "$APPCAST_WORK"
+mkdir -p "$APPCAST_WORK"
+cp "$ARCHIVE" "$APPCAST_WORK/OnlyEQ.app.zip"
+cp "$NOTES" "$APPCAST_WORK/OnlyEQ.app.md"
+
+"$GENERATE_APPCAST" \
+    --account zollans.OnlyEQ \
+    --download-url-prefix "https://github.com/zollans/OnlyEQ/releases/download/v$VERSION/" \
+    --link "https://github.com/zollans/OnlyEQ" \
+    --embed-release-notes \
+    --maximum-versions 1 \
+    --maximum-deltas 0 \
+    "$APPCAST_WORK"
+
+cp "$APPCAST_WORK/appcast.xml" appcast.xml
+
+echo "Prepared OnlyEQ $VERSION"
+echo "  Release archive: $ARCHIVE"
+echo "  Signed appcast: appcast.xml"


### PR DESCRIPTION
## Summary

- integrate Sparkle 2.9.4 with signed automatic checks and background installation
- add a manual **Check for Updates…** command
- add the Ed25519-signed appcast and reproducible release preparation workflow
- bump the app to 1.1.0 (build 4)
- include the post-1.0.2 realtime DSP, spectrum, buffer, and SwiftUI layout optimizations

## Performance

Targeted benchmarks versus 1.0.2 measured:

- 68% less time in the 10-band stereo DSP loop
- 99% less hidden spectrum-capture time
- 93% less active spectrum-capture time

## Release safety

- Sparkle private key remains in the macOS login Keychain; only the public key is committed
- the appcast archive signature and byte length match the release ZIP
- Sparkle framework symlinks and nested helper signatures are preserved
- installer no longer recursively re-signs Sparkle helpers

## Validation

- 60 self-test checks pass
- warning-free release compilation
- universal arm64/x86_64 app build
- deep/strict macOS code-signature verification
- Sparkle Ed25519 archive verification
- extracted release archive passes signature verification and self-tests

1.0.x users need one final manual installation of 1.1.0; releases after 1.1.0 can update automatically.
