### PR TITLE
Show app and macOS versions in Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ swift run OnlyEQ --test               # self-test suite (importer + DSP)
 swift run OnlyEQ --engine-probe       # headless engine check, prints JSON
 swift run OnlyEQ --screenshots out/   # renders the README screenshots
 ./scripts/build-app.sh release        # universal binary release build
-./scripts/prepare-release.sh 1.1.0    # signed archive + appcast
+./scripts/prepare-release.sh 1.1.1    # signed archive + appcast
 ```
 
 Tests run inside the binary because the Command Line Tools don't ship XCTest. Diagnostics land in `~/Library/Logs/OnlyEQ.log`.

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleExecutable</key>
 	<string>OnlyEQ</string>
 	<key>CFBundlePackageType</key>

--- a/Sources/OnlyEQ/UI/SettingsView.swift
+++ b/Sources/OnlyEQ/UI/SettingsView.swift
@@ -45,12 +45,34 @@ struct GeneralSettings: View {
                 Text("Display system audio latency in the popover.")
             }
 
-            LabeledContent("Version") {
-                Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev")
-                    .foregroundStyle(.secondary)
+            Section {
+                LabeledContent("OnlyEQ") {
+                    Text(appVersion)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+                LabeledContent("macOS") {
+                    Text(systemVersion)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            } header: {
+                Text("About")
             }
         }
         .formStyle(.grouped)
+    }
+
+    private var appVersion: String {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "dev"
+        guard let build = info?["CFBundleVersion"] as? String else { return version }
+        return "\(version) (\(build))"
+    }
+
+    private var systemVersion: String {
+        ProcessInfo.processInfo.operatingSystemVersionString
+            .replacingOccurrences(of: "Version ", with: "")
     }
 }
 

--- a/appcast.xml
+++ b/appcast.xml
@@ -3,30 +3,20 @@
     <channel>
         <title>OnlyEQ</title>
         <item>
-            <title>1.1.0</title>
-            <pubDate>Thu, 09 Jul 2026 11:04:10 -0700</pubDate>
+            <title>1.1.1</title>
+            <pubDate>Thu, 09 Jul 2026 11:08:31 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>4</sparkle:version>
-            <sparkle:shortVersionString>1.1.0</sparkle:shortVersionString>
+            <sparkle:version>5</sparkle:version>
+            <sparkle:shortVersionString>1.1.1</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
-            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.1.0
+            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.1.1
 
-This release adds signed automatic updates. After installing 1.1.0, OnlyEQ will check for future releases automatically; you can also right-click the menu-bar icon and choose **Check for Updates…**.
+- Adds an About section to Settings showing the installed OnlyEQ version/build and the full macOS version/build.
+- Includes the automatic updater and realtime CPU optimizations introduced in 1.1.0.
 
-Versions 1.0.x do not contain the updater, so 1.1.0 requires one final manual install.
-
-## Performance
-
-- Stops hidden spectrum capture and peak-meter aggregation at the audio thread, extending 1.0.2's UI visibility gating through the full visualization pipeline.
-- Prevents spectrum frames from triggering a full popover remeasurement and layout pass.
-- Vectorizes spectrum mixing and audio buffer copies with Accelerate.
-- Removes steady-state render-callback allocations and redundant FFT work.
-- Flattens biquad state, uses native Float32 coefficients, and caches limiter constants.
-- Batches spectrum bars into one Canvas path.
-
-Targeted benchmarks versus 1.0.2 measured a 68% reduction in 10-band stereo DSP time, a 99% reduction in hidden spectrum-capture time, and a 93% reduction in active spectrum-capture time.
+Versions 1.0.x do not contain the updater and need one manual installation of 1.1.1. Users already on 1.1.0 can update automatically.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.1.0/OnlyEQ.app.zip" length="2328511" type="application/octet-stream" sparkle:edSignature="W3FYRGdn6KRwrXfO34jRZGY5hhMnFNlABS1TYuC8lSfOl3Ylj8/jrrALYm2Ua7dMgUGwmn7gguf/vOg8TkeBDA=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.1.1/OnlyEQ.app.zip" length="2332812" type="application/octet-stream" sparkle:edSignature="AzC/E/F5huSKPMgrOxmG/sD66+XVeQrcBFzbVFTXVuISBo7/Ufg02lk5L2+TCn0a1JMQVwzZAEw7yJXAAE49Bw=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.1.1.md
+++ b/release-notes/1.1.1.md
@@ -1,0 +1,6 @@
+# OnlyEQ 1.1.1
+
+- Adds an About section to Settings showing the installed OnlyEQ version/build and the full macOS version/build.
+- Includes the automatic updater and realtime CPU optimizations introduced in 1.1.0.
+
+Versions 1.0.x do not contain the updater and need one manual installation of 1.1.1. Users already on 1.1.0 can update automatically.


### PR DESCRIPTION
## Summary

- add an About section to General Settings
- show the installed OnlyEQ version and build number
- show the full macOS version and build number
- bump the patch release to 1.1.1 (build 5)
- publish the newly signed Sparkle appcast entry

## Validation

- 60 self-test checks pass
- warning-free release compilation
- universal arm64/x86_64 app build
- deep/strict macOS code-signature verification
- Sparkle Ed25519 archive verification
