### PR TITLE
Render the editor at 60 fps with lower CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ Plain SwiftPM with no Xcode project. Sparkle is the sole package dependency:
 ```sh
 swift run OnlyEQ --test               # self-test suite (importer + DSP)
 swift run OnlyEQ --engine-probe       # headless engine check, prints JSON
+swift run OnlyEQ --editor-probe       # 15-second editor UI profiling run
 swift run OnlyEQ --screenshots out/   # renders the README screenshots
 ./scripts/build-app.sh release        # universal binary release build
-./scripts/prepare-release.sh 1.1.1    # signed archive + appcast
+./scripts/prepare-release.sh 1.1.2    # signed archive + appcast
 ```
 
 Tests run inside the binary because the Command Line Tools don't ship XCTest. Diagnostics land in `~/Library/Logs/OnlyEQ.log`.

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.1</string>
+	<string>1.1.2</string>
 	<key>CFBundleExecutable</key>
 	<string>OnlyEQ</string>
 	<key>CFBundlePackageType</key>

--- a/Sources/OnlyEQ/App/AppDelegate.swift
+++ b/Sources/OnlyEQ/App/AppDelegate.swift
@@ -50,6 +50,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        AppState.shared.flushWorkingPresetPersistence()
         AppState.shared.engine.stop()
     }
 
@@ -161,7 +162,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
 // Closing the popover only orders its window out — the hosting controller
 // (and the SwiftUI tree inside) stays alive, so PopoverView gates its
-// spectrum TimelineView on this visibility flag to stop it from ticking
+// spectrum animation on this visibility flag to stop it from refreshing
 // forever after the first show.
 extension AppDelegate: NSPopoverDelegate {
     func popoverDidShow(_ notification: Notification) {
@@ -199,7 +200,7 @@ final class WindowManager {
             if !window.setFrameUsingName("EditorWindow") { window.center() }
             window.setFrameAutosaveName("EditorWindow")
             // The window survives close (isReleasedWhenClosed = false, just
-            // ordered out), so EditorView gates its spectrum/clip TimelineViews
+            // ordered out), so EditorView gates its spectrum/clip refresh work
             // on real visibility. Occlusion state also covers "fully covered
             // by another window" and "on another Space", not just close.
             NotificationCenter.default.addObserver(

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -75,7 +75,7 @@ final class AppState: ObservableObject {
 
     /// True only while the popover / editor window is actually on screen.
     /// The popover's content controller and the editor window both outlive
-    /// their close (they're just ordered out), so spectrum/meter TimelineViews
+    /// their close (they're just ordered out), so spectrum/meter animations
     /// gate on these to stop ticking once nothing is visible.
     @Published var popoverIsVisible = false { didSet { updateVisualizationState() } }
     @Published var editorIsVisible = false { didSet { updateVisualizationState() } }
@@ -88,6 +88,7 @@ final class AppState: ObservableObject {
 
     private var deviceListenerInstalled = false
     private var silenceCheckTimer: Timer?
+    private var pendingPresetPersistence: DispatchWorkItem?
 
     /// Sticky per-session flag: once the tap has delivered audio we know the
     /// permission is granted, so engine restarts (device switches, settings
@@ -283,6 +284,24 @@ final class AppState: ObservableObject {
 
     private func persistWorkingPreset() {
         guard !Self.screenshotMode else { return }
+        pendingPresetPersistence?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.writeWorkingPreset()
+        }
+        pendingPresetPersistence = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: work)
+    }
+
+    /// Dragging can publish many preset snapshots per second. Persist only the
+    /// final value, and expose an explicit flush for drag-end and app shutdown.
+    func flushWorkingPresetPersistence() {
+        guard !Self.screenshotMode else { return }
+        pendingPresetPersistence?.cancel()
+        pendingPresetPersistence = nil
+        writeWorkingPreset()
+    }
+
+    private func writeWorkingPreset() {
         if let data = try? JSONEncoder().encode(preset) {
             UserDefaults.standard.set(data, forKey: "workingPreset")
         }

--- a/Sources/OnlyEQ/Audio/SpectrumAnalyzer.swift
+++ b/Sources/OnlyEQ/Audio/SpectrumAnalyzer.swift
@@ -118,9 +118,9 @@ final class SpectrumAnalyzer {
     func bars() -> [Float] {
         guard let fftSetup else { return [] }
 
-        // Popover and editor timelines can fire in the same display cycle. A
-        // short global cache lets both consume one FFT without reducing either
-        // view's 20 Hz refresh rate.
+        // Popover and editor consumers can fire in the same display cycle. A
+        // short global cache lets both share one 30 Hz FFT result while their
+        // presentation layers animate independently.
         let now = ProcessInfo.processInfo.systemUptime
         if now - lastAnalysisTime < Self.analysisReuseInterval { return barsOut }
 

--- a/Sources/OnlyEQ/UI/EQCurveView.swift
+++ b/Sources/OnlyEQ/UI/EQCurveView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import AppKit
+import QuartzCore
 
 enum BandPalette {
     static let colors: [Color] = [.blue, .teal, .purple, .pink, .orange, .green, .indigo, .mint, .red, .cyan]
@@ -24,6 +26,7 @@ struct EQCurveView: View {
     var rangeDB: Double = 12
     @Binding var selectedBandID: UUID?
     var onBandChange: ((UUID, _ frequency: Double, _ gain: Double) -> Void)?
+    var onBandDragEnded: (() -> Void)?
     var onAddBand: ((_ frequency: Double, _ gain: Double) -> Void)?
 
     private let minF = 20.0, maxF = 20000.0
@@ -33,6 +36,7 @@ struct EQCurveView: View {
          showIndividualCurves: Bool = false, rangeDB: Double = 12,
          selectedBandID: Binding<UUID?> = .constant(nil),
          onBandChange: ((UUID, Double, Double) -> Void)? = nil,
+         onBandDragEnded: (() -> Void)? = nil,
          onAddBand: ((Double, Double) -> Void)? = nil) {
         self.bands = bands
         self.preampDB = preampDB
@@ -43,6 +47,7 @@ struct EQCurveView: View {
         self.rangeDB = rangeDB
         self._selectedBandID = selectedBandID
         self.onBandChange = onBandChange
+        self.onBandDragEnded = onBandDragEnded
         self.onAddBand = onAddBand
     }
 
@@ -51,7 +56,7 @@ struct EQCurveView: View {
             let size = geo.size
             ZStack {
                 gridLayer(size: size)
-                if showSpectrum { SpectrumBarsView(style: spectrumStyle, size: size) }
+                if showSpectrum { SpectrumBarsView(style: spectrumStyle) }
                 curveLayer(size: size)
                 if interactive { nodeLayer(size: size) }
             }
@@ -145,23 +150,15 @@ struct EQCurveView: View {
     @ViewBuilder
     private func nodeLayer(size: CGSize) -> some View {
         ForEach(Array(bands.enumerated()), id: \.element.id) { index, band in
-            let isSelected = selectedBandID == band.id
-            Circle()
-                .fill(BandPalette.color(index))
-                .frame(width: isSelected ? 14 : 11, height: isSelected ? 14 : 11)
-                .overlay(Circle().stroke(.white.opacity(isSelected ? 0.9 : 0.5), lineWidth: isSelected ? 2 : 1))
-                .opacity(band.isEnabled ? 1 : 0.35)
-                .position(x: x(forFrequency: band.frequency, size),
-                          y: y(forDB: min(max(band.gain, -rangeDB), rangeDB), size))
-                .gesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { value in
-                            selectedBandID = band.id
-                            let f = min(max(frequency(atX: value.location.x, size), minF), maxF)
-                            let g = min(max(dB(atY: value.location.y, size), -rangeDB), rangeDB)
-                            onBandChange?(band.id, f, (g * 10).rounded() / 10)
-                        }
-                )
+            DraggableBandNode(
+                index: index,
+                band: band,
+                size: size,
+                rangeDB: rangeDB,
+                selectedBandID: $selectedBandID,
+                onChange: onBandChange,
+                onEnded: onBandDragEnded
+            )
         }
     }
 
@@ -174,36 +171,214 @@ struct EQCurveView: View {
     }
 }
 
-/// Live spectrum bars in their own TimelineView-driven Canvas: the periodic
-/// refresh redraws only this layer, instead of re-evaluating the whole curve
-/// view (grid, response curve, drag nodes) 20× per second like the old
-/// Timer + @State approach did.
-private struct SpectrumBarsView: View {
+/// Hosts the animated spectrum in an AppKit layer. Updating the layer's path
+/// does not invalidate SwiftUI's editor graph or trigger a window layout pass.
+private struct SpectrumBarsView: NSViewRepresentable {
     var style: EQCurveView.SpectrumStyle
-    var size: CGSize
 
-    private let spectrum = AppState.shared.engine.spectrum
+    func makeNSView(context: Context) -> SpectrumBarsNSView {
+        let view = SpectrumBarsNSView(spectrum: AppState.shared.engine.spectrum)
+        view.configure(style: style)
+        return view
+    }
 
-    var body: some View {
-        TimelineView(.periodic(from: .now, by: 1.0 / 20)) { timeline in
-            // Read the date and capture it in the Canvas closure — otherwise
-            // SwiftUI sees no dependency on the schedule and never redraws.
-            let date = timeline.date
-            Canvas { ctx, _ in
-                _ = date
-                let bars = spectrum.bars()
-                guard !bars.isEmpty else { return }
-                let barWidth = size.width / CGFloat(bars.count)
-                var path = Path()
-                for (i, level) in bars.enumerated() {
-                    let h = CGFloat(level) * size.height * style.heightScale
-                    let rect = CGRect(x: CGFloat(i) * barWidth + 1, y: size.height - h,
-                                      width: max(barWidth - 2, 1), height: h)
-                    path.addRect(rect)
-                }
-                ctx.fill(path, with: .color(.secondary.opacity(style.opacity)))
+    func updateNSView(_ view: SpectrumBarsNSView, context: Context) {
+        view.configure(style: style)
+    }
+
+    static func dismantleNSView(_ view: SpectrumBarsNSView, coordinator: ()) {
+        view.stopAnimating()
+    }
+}
+
+@MainActor
+private final class SpectrumBarsNSView: NSView {
+    private let spectrum: SpectrumAnalyzer
+    private let barsLayer = CAShapeLayer()
+    private var animationLink: CADisplayLink?
+    private var targetBars = [Float](repeating: 0, count: SpectrumAnalyzer.barCount)
+    private var displayedBars = [Float](repeating: 0, count: SpectrumAnalyzer.barCount)
+    private var lastAnalysisTime: CFTimeInterval = 0
+    private var barOpacity = 0.10
+    private var heightScale = 0.75
+
+    init(spectrum: SpectrumAnalyzer) {
+        self.spectrum = spectrum
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.masksToBounds = true
+        barsLayer.actions = ["path": NSNull(), "fillColor": NSNull(), "bounds": NSNull(), "position": NSNull()]
+        layer?.addSublayer(barsLayer)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(style: EQCurveView.SpectrumStyle) {
+        barOpacity = style.opacity
+        heightScale = style.heightScale
+        updateColors()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window == nil { stopAnimating() } else { startAnimating() }
+    }
+
+    override func layout() {
+        super.layout()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        barsLayer.frame = bounds
+        CATransaction.commit()
+        renderBars(displayedBars)
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateColors()
+    }
+
+    func stopAnimating() {
+        animationLink?.invalidate()
+        animationLink = nil
+    }
+
+    private func startAnimating() {
+        guard animationLink == nil else { return }
+        targetBars.withUnsafeMutableBufferPointer { $0.update(repeating: 0) }
+        displayedBars.withUnsafeMutableBufferPointer { $0.update(repeating: 0) }
+        lastAnalysisTime = 0
+
+        let link = displayLink(target: self, selector: #selector(displayLinkDidFire(_:)))
+        link.preferredFrameRateRange = CAFrameRateRange(minimum: 60, maximum: 60, preferred: 60)
+        link.add(to: .main, forMode: .common)
+        animationLink = link
+        renderBars(displayedBars)
+    }
+
+    private func updateColors() {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        barsLayer.fillColor = NSColor.secondaryLabelColor.withAlphaComponent(barOpacity).cgColor
+        CATransaction.commit()
+    }
+
+    @objc private func displayLinkDidFire(_ link: CADisplayLink) {
+        // FFT/magnitude work stays capped at 30 Hz. The layer interpolates the
+        // latest targets at 60 fps, so motion is smooth without doubling DSP.
+        if lastAnalysisTime == 0 || link.timestamp - lastAnalysisTime >= 1.0 / 30.0 {
+            let bars = spectrum.bars()
+            if bars.count == targetBars.count {
+                for index in bars.indices { targetBars[index] = bars[index] }
+            }
+            lastAnalysisTime = link.timestamp
+        }
+
+        let duration = max(link.duration, 1.0 / 120.0)
+        let blend = Float(1 - exp(-duration / 0.045))
+        var changed = false
+        for index in displayedBars.indices {
+            let delta = targetBars[index] - displayedBars[index]
+            if abs(delta) > 0.0005 {
+                displayedBars[index] += delta * blend
+                changed = true
+            } else {
+                displayedBars[index] = targetBars[index]
             }
         }
+        if changed { renderBars(displayedBars) }
+    }
+
+    private func renderBars(_ bars: [Float]) {
+        let size = bounds.size
+        guard size.width > 0, size.height > 0 else { return }
+        guard !bars.isEmpty else { return }
+
+        let barWidth = size.width / CGFloat(bars.count)
+        let path = CGMutablePath()
+        for (index, level) in bars.enumerated() {
+            let height = CGFloat(level) * size.height * heightScale
+            path.addRect(CGRect(x: CGFloat(index) * barWidth + 1, y: 0,
+                                width: max(barWidth - 2, 1), height: height))
+        }
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        barsLayer.path = path
+        CATransaction.commit()
+    }
+
+    deinit {
+        animationLink?.invalidate()
+    }
+}
+
+/// Keeps pointer tracking local to a single node. The node follows every mouse
+/// event immediately, while model/audio updates are capped at the display rate
+/// so a high-polling-rate mouse cannot rebuild the entire editor hundreds of
+/// times per second.
+private struct DraggableBandNode: View {
+    let index: Int
+    let band: EQBand
+    let size: CGSize
+    let rangeDB: Double
+    @Binding var selectedBandID: UUID?
+    let onChange: ((UUID, Double, Double) -> Void)?
+    let onEnded: (() -> Void)?
+
+    @State private var dragPosition: CGPoint?
+    @State private var lastModelUpdate: CFTimeInterval = 0
+
+    private let minF = 20.0, maxF = 20000.0
+
+    var body: some View {
+        let isSelected = selectedBandID == band.id
+        Circle()
+            .fill(BandPalette.color(index))
+            .frame(width: isSelected ? 14 : 11, height: isSelected ? 14 : 11)
+            .overlay(Circle().stroke(.white.opacity(isSelected ? 0.9 : 0.5),
+                                     lineWidth: isSelected ? 2 : 1))
+            .opacity(band.isEnabled ? 1 : 0.35)
+            .position(dragPosition ?? CGPoint(x: x(forFrequency: band.frequency),
+                                              y: y(forDB: band.gain)))
+            .gesture(DragGesture(minimumDistance: 0)
+                .onChanged { value in
+                    if selectedBandID != band.id { selectedBandID = band.id }
+                    let update = mapped(value.location)
+                    dragPosition = update.position
+
+                    let now = CACurrentMediaTime()
+                    if lastModelUpdate == 0 || now - lastModelUpdate >= 1.0 / 60.0 {
+                        onChange?(band.id, update.frequency, update.gain)
+                        lastModelUpdate = now
+                    }
+                }
+                .onEnded { value in
+                    let update = mapped(value.location)
+                    onChange?(band.id, update.frequency, update.gain)
+                    dragPosition = nil
+                    lastModelUpdate = 0
+                    onEnded?()
+                })
+    }
+
+    private func x(forFrequency frequency: Double) -> CGFloat {
+        CGFloat((log10(frequency) - log10(minF)) / (log10(maxF) - log10(minF))) * size.width
+    }
+
+    private func y(forDB db: Double) -> CGFloat {
+        CGFloat(0.5 - min(max(db, -rangeDB), rangeDB) / (rangeDB * 2)) * size.height
+    }
+
+    private func mapped(_ location: CGPoint) -> (position: CGPoint, frequency: Double, gain: Double) {
+        let px = min(max(location.x, 0), size.width)
+        let py = min(max(location.y, 0), size.height)
+        let frequency = pow(10, log10(minF) + Double(px / size.width) * (log10(maxF) - log10(minF)))
+        let rawGain = (0.5 - Double(py / size.height)) * rangeDB * 2
+        let gain = (min(max(rawGain, -rangeDB), rangeDB) * 10).rounded() / 10
+        return (CGPoint(x: px, y: py), frequency, gain)
     }
 }
 

--- a/Sources/OnlyEQ/UI/EditorView.swift
+++ b/Sources/OnlyEQ/UI/EditorView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import Combine
+import AppKit
+import QuartzCore
 
 /// The EQ editor window: toolbar, interactive graph, band strip, bottom bar.
 struct EditorView: View {
@@ -112,6 +114,9 @@ struct EditorView: View {
                     state.preset.bands[i].frequency = f
                     state.preset.bands[i].gain = g
                 },
+                onBandDragEnded: {
+                    state.flushWorkingPresetPersistence()
+                },
                 onAddBand: { f, g in
                     guard state.preset.bands.count < 32 else { return }
                     let band = EQBand(type: .peak, frequency: f, gain: g, q: 1.41)
@@ -208,30 +213,9 @@ struct EditorView: View {
         .padding(.vertical, 8)
     }
 
-    // The window survives close (only ordered out), so the meter's timer is
-    // gated on real visibility — otherwise it would tick forever after the
-    // window is first shown.
-    @ViewBuilder
     private var clipIndicator: some View {
-        if state.editorIsVisible {
-            TimelineView(.periodic(from: .now, by: 0.25)) { _ in
-                clipReadout(peak: state.engine.processor.currentPeak)
-            }
-        } else {
-            clipReadout(peak: 0)
-        }
-    }
-
-    private func clipReadout(peak: Float) -> some View {
-        let db = peak > 0 ? 20 * log10(Double(peak)) : -60
-        return HStack(spacing: 4) {
-            Circle()
-                .fill(db > -0.1 ? Color.red : (db > -3 ? .orange : .green))
-                .frame(width: 7, height: 7)
-            Text(String(format: "%.1f dBFS", max(db, -60)))
-                .font(.system(size: 10).monospacedDigit())
-                .foregroundStyle(.secondary)
-        }
+        PeakMeterView(processor: state.engine.processor, isActive: state.editorIsVisible)
+            .frame(width: 78, height: 14)
     }
 
     private var saveSheet: some View {
@@ -251,6 +235,127 @@ struct EditorView: View {
             }
         }
         .padding(20)
+    }
+}
+
+/// Keeps the display-linked peak readout out of SwiftUI's view graph. Updating this
+/// AppKit view redraws only its 78×14-point bounds instead of the editor.
+private struct PeakMeterView: NSViewRepresentable {
+    let processor: EQProcessor
+    let isActive: Bool
+
+    func makeNSView(context: Context) -> PeakMeterNSView {
+        let view = PeakMeterNSView(processor: processor)
+        view.setActive(isActive)
+        return view
+    }
+
+    func updateNSView(_ view: PeakMeterNSView, context: Context) {
+        view.setActive(isActive)
+    }
+
+    static func dismantleNSView(_ view: PeakMeterNSView, coordinator: ()) {
+        view.stopAnimating()
+    }
+}
+
+@MainActor
+private final class PeakMeterNSView: NSView {
+    private let processor: EQProcessor
+    private let dotLayer = CAShapeLayer()
+    private let textLayer = CATextLayer()
+    private var animationLink: CADisplayLink?
+    private var active = false
+    private var db: Double = -60
+    private var renderedLabel = ""
+    private var renderedColor: NSColor?
+
+    init(processor: EQProcessor) {
+        self.processor = processor
+        super.init(frame: .zero)
+        wantsLayer = true
+        dotLayer.actions = ["path": NSNull(), "fillColor": NSNull()]
+        textLayer.actions = ["string": NSNull(), "foregroundColor": NSNull(),
+                             "bounds": NSNull(), "position": NSNull()]
+        textLayer.font = NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .regular)
+        textLayer.fontSize = 10
+        textLayer.alignmentMode = .left
+        layer?.addSublayer(dotLayer)
+        layer?.addSublayer(textLayer)
+        updateLayers(force: true)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var isOpaque: Bool { false }
+
+    override func layout() {
+        super.layout()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        dotLayer.path = CGPath(ellipseIn: CGRect(x: 0, y: max((bounds.height - 7) / 2, 0),
+                                                 width: 7, height: 7), transform: nil)
+        textLayer.frame = CGRect(x: 11, y: 0, width: max(bounds.width - 11, 0), height: bounds.height)
+        textLayer.contentsScale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
+        CATransaction.commit()
+    }
+
+    func setActive(_ active: Bool) {
+        guard self.active != active else { return }
+        self.active = active
+        if active, window != nil {
+            startAnimating()
+        } else {
+            stopAnimating()
+            db = -60
+            updateLayers(force: true)
+        }
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if active, window != nil { startAnimating() } else { stopAnimating() }
+    }
+
+    private func updateLayers(force: Bool = false) {
+        let color: NSColor = db > -0.1 ? .systemRed : (db > -3 ? .systemOrange : .systemGreen)
+        let label = String(format: "%.1f dBFS", max(db, -60))
+        guard force || label != renderedLabel || color != renderedColor else { return }
+        renderedLabel = label
+        renderedColor = color
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        dotLayer.fillColor = color.cgColor
+        textLayer.string = label
+        textLayer.foregroundColor = NSColor.secondaryLabelColor.cgColor
+        CATransaction.commit()
+    }
+
+    func stopAnimating() {
+        animationLink?.invalidate()
+        animationLink = nil
+    }
+
+    private func startAnimating() {
+        guard animationLink == nil else { return }
+        let link = displayLink(target: self, selector: #selector(samplePeak(_:)))
+        link.preferredFrameRateRange = CAFrameRateRange(minimum: 60, maximum: 60, preferred: 60)
+        link.add(to: .main, forMode: .common)
+        animationLink = link
+        samplePeak(link)
+    }
+
+    @objc private func samplePeak(_ link: CADisplayLink) {
+        let peak = processor.currentPeak
+        db = peak > 0 ? 20 * log10(Double(peak)) : -60
+        updateLayers()
+    }
+
+    deinit {
+        animationLink?.invalidate()
     }
 }
 

--- a/Sources/OnlyEQ/main.swift
+++ b/Sources/OnlyEQ/main.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CoreAudio
+import SwiftUI
 
 if CommandLine.arguments.contains("--test") {
     exit(TestRunner.run())
@@ -15,6 +16,37 @@ if let flagIndex = CommandLine.arguments.firstIndex(of: "--screenshots") {
         app.setActivationPolicy(.accessory)
         app.finishLaunching()
         exit(ScreenshotRenderer.run(outputDir: outputDir))
+    }
+}
+
+// Opens the real editor view for a short, side-effect-free UI profiling run.
+// The engine stays off; the process exits automatically after 15 seconds.
+if CommandLine.arguments.contains("--editor-probe") {
+    MainActor.assumeIsolated {
+        AppState.screenshotMode = true
+        let app = NSApplication.shared
+        app.setActivationPolicy(.regular)
+        app.finishLaunching()
+
+        let state = AppState.shared
+        state.engineState = .running
+        state.editorIsVisible = true
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 840, height: 560),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "OnlyEQ UI Probe"
+        window.contentViewController = NSHostingController(
+            rootView: EditorView().environmentObject(state)
+        )
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        app.activate(ignoringOtherApps: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 15) { app.terminate(nil) }
+        app.run()
+        exit(0)
     }
 }
 

--- a/appcast.xml
+++ b/appcast.xml
@@ -3,20 +3,22 @@
     <channel>
         <title>OnlyEQ</title>
         <item>
-            <title>1.1.1</title>
-            <pubDate>Thu, 09 Jul 2026 11:08:31 -0700</pubDate>
+            <title>1.1.2</title>
+            <pubDate>Thu, 09 Jul 2026 12:58:12 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>5</sparkle:version>
-            <sparkle:shortVersionString>1.1.1</sparkle:shortVersionString>
+            <sparkle:version>6</sparkle:version>
+            <sparkle:shortVersionString>1.1.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
-            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.1.1
+            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.1.2
 
-- Adds an About section to Settings showing the installed OnlyEQ version/build and the full macOS version/build.
-- Includes the automatic updater and realtime CPU optimizations introduced in 1.1.0.
-
-Versions 1.0.x do not contain the updater and need one manual installation of 1.1.1. Users already on 1.1.0 can update automatically.
+- Makes the editor spectrum display-linked and smoothly interpolated at 60 fps.
+- Keeps FFT analysis capped at 30 Hz and moves bar drawing into an isolated Core Animation layer, avoiding full SwiftUI editor layout on every frame.
+- Updates the peak meter at 60 Hz using cached text and shape layers, with no redraw when its displayed value is unchanged.
+- Makes EQ node dragging track the pointer immediately while capping model/audio updates at 60 Hz.
+- Coalesces working-preset persistence during dragging and flushes the final value at drag end or app shutdown.
+- Adds a side-effect-free editor profiling mode for performance regression checks.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.1.1/OnlyEQ.app.zip" length="2332812" type="application/octet-stream" sparkle:edSignature="AzC/E/F5huSKPMgrOxmG/sD66+XVeQrcBFzbVFTXVuISBo7/Ufg02lk5L2+TCn0a1JMQVwzZAEw7yJXAAE49Bw=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.1.2/OnlyEQ.app.zip" length="2362639" type="application/octet-stream" sparkle:edSignature="6QbfYMxm/XLq3FWItD/WOO7ULgO72pfV2QNtAgHsoTjtGKJVgPTFkgq85c/XhmuRyuUrPmxZ4j2NZDTrEHWwAQ=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.1.2.md
+++ b/release-notes/1.1.2.md
@@ -1,0 +1,8 @@
+# OnlyEQ 1.1.2
+
+- Makes the editor spectrum display-linked and smoothly interpolated at 60 fps.
+- Keeps FFT analysis capped at 30 Hz and moves bar drawing into an isolated Core Animation layer, avoiding full SwiftUI editor layout on every frame.
+- Updates the peak meter at 60 Hz using cached text and shape layers, with no redraw when its displayed value is unchanged.
+- Makes EQ node dragging track the pointer immediately while capping model/audio updates at 60 Hz.
+- Coalesces working-preset persistence during dragging and flushes the final value at drag end or app shutdown.
+- Adds a side-effect-free editor profiling mode for performance regression checks.


### PR DESCRIPTION
## Summary

OnlyEQ now renders its live editor visualization at a smooth 60 fps while using a small fraction of the CPU shown by the previous SwiftUI-driven implementation. EQ nodes also stay attached to the pointer during dragging without flooding the full editor, audio model, or preference store with redundant updates.

## Why

The editor consumed roughly 26.5% CPU in the reported real-world case even though it was primarily drawing spectrum bars. Its 15 Hz spectrum and 4 Hz meter also looked visibly slow, and node dragging inherited the cost of broad SwiftUI updates and synchronous preset persistence.

## What

- Move spectrum presentation to an isolated AppKit/Core Animation shape layer.
- Drive presentation at 60 fps while sharing cached FFT targets capped at 30 Hz.
- Move the 60 Hz peak meter to cached Core Animation text and shape layers.
- Track drag position locally at pointer speed and cap broad model/audio updates at 60 Hz.
- Coalesce working-preset writes and flush the final drag value.
- Add a side-effect-free editor profiling mode.
- Prepare the signed universal 1.1.2 updater artifact and appcast entry.

## Solution

```mermaid
flowchart LR
    Audio[Audio samples] --> FFT[FFT targets at max 30 Hz]
    FFT --> Interpolation[Display-linked interpolation at 60 fps]
    Interpolation --> Bars[Core Animation bar layer]
    Meter[Peak samples at 60 Hz] --> Cache[Cached label and color]
    Cache --> MeterLayers[Text and shape layers]
    Pointer[Pointer events] --> Node[Local node position]
    Node -->|max 60 Hz| Model[EQ model and audio snapshot]
    Model -->|coalesced| Persistence[Working preset storage]
```

Review order:

1. `Sources/OnlyEQ/UI/EQCurveView.swift` — spectrum architecture and responsive node dragging.
2. `Sources/OnlyEQ/UI/EditorView.swift` — meter layers and editor integration.
3. `Sources/OnlyEQ/App/AppState.swift` — persistence coalescing.
4. `Sources/OnlyEQ/main.swift` — profiling harness.
5. Release metadata and notes.

## Types of Changes

- [x] Performance improvement
- [x] User-visible enhancement
- [x] Release metadata
- [ ] Breaking change

## Test Plan

- `swift build -c release -Xswiftc -warnings-as-errors`
- `swift run -c release OnlyEQ --test` — 60 checks passed, 0 failed.
- `swift run -c release OnlyEQ --editor-probe` — full editor open at 60 Hz, typically 0.4–1.1% CPU after launch versus the reported 26.5% before.
- `codesign --verify --deep --strict --verbose=2 build/OnlyEQ.app`
- `lipo -archs build/OnlyEQ.app/Contents/MacOS/OnlyEQ` — x86_64 arm64.
- `unzip -t build/OnlyEQ.app.zip` — no errors.

## Related Issues

No issue was provided; this follows the user performance report and screenshot.