### PR TITLE
Suggest presets for new Bluetooth headphones

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ Plain SwiftPM with no Xcode project. Sparkle is the sole package dependency:
 swift run OnlyEQ --test               # self-test suite (importer + DSP)
 swift run OnlyEQ --engine-probe       # headless engine check, prints JSON
 swift run OnlyEQ --editor-probe       # 15-second editor UI profiling run
+swift run OnlyEQ --profile-suggestion-probe # previews Bluetooth profile discovery
 swift run OnlyEQ --screenshots out/   # renders the README screenshots
 ./scripts/build-app.sh release        # universal binary release build
-./scripts/prepare-release.sh 1.1.2    # signed archive + appcast
+./scripts/prepare-release.sh 1.2.0    # signed archive + appcast
 ```
 
 Tests run inside the binary because the Command Line Tools don't ship XCTest. Diagnostics land in `~/Library/Logs/OnlyEQ.log`.

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.2.0</string>
 	<key>CFBundleExecutable</key>
 	<string>OnlyEQ</string>
 	<key>CFBundlePackageType</key>

--- a/Sources/OnlyEQ/App/AppDelegate.swift
+++ b/Sources/OnlyEQ/App/AppDelegate.swift
@@ -18,6 +18,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         NSApp.setActivationPolicy(.accessory)
 
         let state = AppState.shared
+        state.onProfileSuggestion = { suggestion in
+            WindowManager.shared.showEditor(importing: true, profileSuggestion: suggestion)
+        }
         Log.write("app: state ready")
 
         popover = NSPopover()
@@ -183,7 +186,8 @@ final class WindowManager {
     private var settingsWindow: NSWindow?
     private var onboardingWindow: NSWindow?
 
-    func showEditor(importing: Bool = false) {
+    func showEditor(importing: Bool = false, profileSuggestion: ProfileSuggestion? = nil) {
+        let isCreatingWindow = editorWindow == nil
         if editorWindow == nil {
             let window = NSWindow(
                 contentRect: NSRect(x: 0, y: 0, width: 840, height: 560),
@@ -194,7 +198,9 @@ final class WindowManager {
             window.minSize = NSSize(width: 720, height: 480)
             window.isReleasedWhenClosed = false
             window.contentViewController = NSHostingController(
-                rootView: EditorView().environmentObject(AppState.shared)
+                rootView: EditorView(initialImportRequested: importing,
+                                     initialProfileSuggestion: profileSuggestion)
+                    .environmentObject(AppState.shared)
             )
             // Restore the saved frame if there is one; otherwise center.
             if !window.setFrameUsingName("EditorWindow") { window.center() }
@@ -213,9 +219,11 @@ final class WindowManager {
             }
             editorWindow = window
         }
-        if importing { EditorView.importRequested.send() }
         editorWindow?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+        if importing, !isCreatingWindow {
+            EditorView.importRequested.send(profileSuggestion)
+        }
     }
 
     func showSettings() {

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -17,6 +17,10 @@ final class AppState: ObservableObject {
     let store = PresetStore()
     let onlineDB = OnlineDatabase()
 
+    /// Installed by the app delegate so device detection can request UI without
+    /// coupling the audio/state layer to a particular window implementation.
+    var onProfileSuggestion: ((ProfileSuggestion) -> Void)?
+
     // MARK: - Published state
 
     @Published var isEnabled: Bool = UserDefaults.standard.object(forKey: "enabled") as? Bool ?? true {
@@ -66,6 +70,10 @@ final class AppState: ObservableObject {
         didSet { UserDefaults.standard.set(bufferFrames, forKey: "bufferFrames"); engine.setIOBufferFrames(bufferFrames) }
     }
 
+    @Published var autoSuggestHeadphoneProfiles: Bool = UserDefaults.standard.object(forKey: "autoSuggestHeadphoneProfiles") as? Bool ?? true {
+        didSet { UserDefaults.standard.set(autoSuggestHeadphoneProfiles, forKey: "autoSuggestHeadphoneProfiles") }
+    }
+
     /// A/B comparison slots.
     @Published var abSlot: Int = 0
     private var abPresets: [EQPreset?] = [nil, nil]
@@ -89,6 +97,7 @@ final class AppState: ObservableObject {
     private var deviceListenerInstalled = false
     private var silenceCheckTimer: Timer?
     private var pendingPresetPersistence: DispatchWorkItem?
+    private var suggestedDeviceUIDs = Set(UserDefaults.standard.stringArray(forKey: "profileSuggestion.seenDeviceUIDs") ?? [])
 
     /// Sticky per-session flag: once the tap has delivered audio we know the
     /// permission is granted, so engine restarts (device switches, settings
@@ -202,6 +211,24 @@ final class AppState: ObservableObject {
         refreshDevices()
         if isEnabled { rebuildEngine() }
         applyDeviceProfileIfNeeded()
+        suggestProfileForCurrentDeviceIfNeeded()
+    }
+
+    private func suggestProfileForCurrentDeviceIfNeeded() {
+        guard UserDefaults.standard.bool(forKey: "onboarded"),
+              autoSuggestHeadphoneProfiles,
+              let device = currentDevice,
+              device.isBluetooth,
+              store.deviceProfiles[device.uid] == nil,
+              !suggestedDeviceUIDs.contains(device.uid),
+              let onProfileSuggestion else { return }
+
+        let query = HeadphoneNameMatcher.searchQuery(for: device.name)
+        guard !query.isEmpty else { return }
+        suggestedDeviceUIDs.insert(device.uid)
+        UserDefaults.standard.set(Array(suggestedDeviceUIDs), forKey: "profileSuggestion.seenDeviceUIDs")
+        onProfileSuggestion(ProfileSuggestion(deviceUID: device.uid, deviceName: device.name,
+                                              searchQuery: query))
     }
 
     private func applyDeviceProfileIfNeeded() {
@@ -238,6 +265,16 @@ final class AppState: ObservableObject {
         store.save(toSave)
         preset = toSave
         presetWasAutoApplied = false
+    }
+
+    func assignSuggestedPreset(_ preset: EQPreset, to suggestion: ProfileSuggestion) {
+        store.save(preset)
+        store.setProfile(deviceUID: suggestion.deviceUID, deviceName: suggestion.deviceName,
+                         preset: preset, autoApply: true)
+        if currentDevice?.uid == suggestion.deviceUID {
+            self.preset = preset
+            presetWasAutoApplied = true
+        }
     }
 
     // MARK: - A/B

--- a/Sources/OnlyEQ/Audio/AudioDeviceManager.swift
+++ b/Sources/OnlyEQ/Audio/AudioDeviceManager.swift
@@ -8,6 +8,11 @@ struct AudioOutputDevice: Identifiable, Hashable {
     var name: String
     var transportType: UInt32
 
+    var isBluetooth: Bool {
+        transportType == kAudioDeviceTransportTypeBluetooth
+            || transportType == kAudioDeviceTransportTypeBluetoothLE
+    }
+
     var icon: String {
         // The device name is a better signal than the transport (e.g. the
         // 3.5 mm jack reports transport "built-in" but is named "External Headphones").

--- a/Sources/OnlyEQ/Models/ProfileSuggestion.swift
+++ b/Sources/OnlyEQ/Models/ProfileSuggestion.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Context passed from device detection into the existing online preset browser.
+struct ProfileSuggestion: Equatable {
+    var deviceUID: String
+    var deviceName: String
+    var searchQuery: String
+}
+
+enum HeadphoneNameMatcher {
+    private static let ignoredWords: Set<String> = [
+        "audio", "bluetooth", "headphone", "headphones", "headset", "le",
+        "stereo", "wireless",
+    ]
+
+    /// Turns names exposed by Core Audio into a useful catalog query. Examples:
+    /// “Aaron’s WH-1000XM5 Stereo” → “WH-1000XM5”.
+    static func searchQuery(for deviceName: String) -> String {
+        var name = deviceName.trimmingCharacters(in: .whitespacesAndNewlines)
+        name = name.replacingOccurrences(
+            of: #"^[^\s]+[’']s\s+"#,
+            with: "",
+            options: [.regularExpression, .caseInsensitive]
+        )
+        name = name.replacingOccurrences(
+            of: #"\s*[\(\[](?:bluetooth|stereo|wireless|audio)[^\)\]]*[\)\]]\s*"#,
+            with: " ",
+            options: [.regularExpression, .caseInsensitive]
+        )
+        name = name.replacingOccurrences(of: #"^(?:LE[_\-\s]+)"#, with: "",
+                                         options: [.regularExpression, .caseInsensitive])
+
+        let words = name.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        let useful = words.filter { !ignoredWords.contains(normalizedWord($0)) }
+        return (useful.isEmpty ? words : useful).joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Deterministic score used only to choose among catalog results. Model
+    /// numbers and exact containment intentionally outweigh general word overlap.
+    static func score(query: String, candidate: String) -> Double {
+        let queryWords = normalizedWords(query)
+        let candidateWords = normalizedWords(candidate)
+        guard !queryWords.isEmpty, !candidateWords.isEmpty else { return 0 }
+
+        let queryJoined = queryWords.joined()
+        let candidateJoined = candidateWords.joined()
+        if queryJoined == candidateJoined { return 1 }
+        if candidateJoined.contains(queryJoined) || queryJoined.contains(candidateJoined) { return 0.96 }
+
+        let candidateSet = Set(candidateWords)
+        let exactMatches = queryWords.filter(candidateSet.contains)
+        let exactRatio = Double(exactMatches.count) / Double(queryWords.count)
+        let modelWords = queryWords.filter { $0.contains(where: \.isNumber) }
+        let modelRatio = modelWords.isEmpty ? 0 : Double(modelWords.filter(candidateSet.contains).count) / Double(modelWords.count)
+        return min(0.95, exactRatio * 0.65 + modelRatio * 0.30)
+    }
+
+    private static func normalizedWords(_ value: String) -> [String] {
+        value.lowercased().split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+            .map(String.init)
+            .filter { !ignoredWords.contains($0) }
+    }
+
+    private static func normalizedWord(_ value: String) -> String {
+        value.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+}

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -181,5 +181,14 @@ enum TestRunner {
         analyzer.setActive(false)
         analyzer.setActive(true)
         expect(analyzer.bars().allSatisfy { $0 == 0 }, "reactivating spectrum starts with a cleared ring")
+
+        // Bluetooth device-name cleanup and deterministic catalog ranking.
+        expect(HeadphoneNameMatcher.searchQuery(for: "Aaron’s WH-1000XM5 Stereo") == "WH-1000XM5",
+               "headphone matcher strips owner and Bluetooth noise")
+        expect(HeadphoneNameMatcher.searchQuery(for: "LE_AirPods Pro") == "AirPods Pro",
+               "headphone matcher strips Bluetooth LE prefix")
+        expect(HeadphoneNameMatcher.score(query: "WH-1000XM5", candidate: "Sony WH-1000XM5")
+               > HeadphoneNameMatcher.score(query: "WH-1000XM5", candidate: "Sony WH-1000XM4"),
+               "headphone matcher prioritizes exact model number")
     }
 }

--- a/Sources/OnlyEQ/UI/EditorView.swift
+++ b/Sources/OnlyEQ/UI/EditorView.swift
@@ -3,15 +3,24 @@ import Combine
 import AppKit
 import QuartzCore
 
+private struct ImportPresentation: Identifiable {
+    let id = UUID()
+    var profileSuggestion: ProfileSuggestion?
+}
+
 /// The EQ editor window: toolbar, interactive graph, band strip, bottom bar.
 struct EditorView: View {
-    static let importRequested = PassthroughSubject<Void, Never>()
+    static let importRequested = PassthroughSubject<ProfileSuggestion?, Never>()
+
+    var initialImportRequested = false
+    var initialProfileSuggestion: ProfileSuggestion?
 
     @EnvironmentObject var state: AppState
     @State private var selectedBandID: UUID?
-    @State private var showImportSheet = false
+    @State private var importPresentation: ImportPresentation?
     @State private var showSaveSheet = false
     @State private var saveName = ""
+    @State private var handledInitialImport = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -22,11 +31,18 @@ struct EditorView: View {
             Divider()
             bottomBar
         }
-        .sheet(isPresented: $showImportSheet) {
-            ImportSheet().environmentObject(state)
+        .sheet(item: $importPresentation) { presentation in
+            ImportSheet(profileSuggestion: presentation.profileSuggestion).environmentObject(state)
         }
         .sheet(isPresented: $showSaveSheet) { saveSheet }
-        .onReceive(Self.importRequested) { _ in showImportSheet = true }
+        .onReceive(Self.importRequested) { suggestion in
+            importPresentation = ImportPresentation(profileSuggestion: suggestion)
+        }
+        .onAppear {
+            guard initialImportRequested, !handledInitialImport else { return }
+            handledInitialImport = true
+            importPresentation = ImportPresentation(profileSuggestion: initialProfileSuggestion)
+        }
     }
 
     // MARK: - Toolbar
@@ -77,7 +93,7 @@ struct EditorView: View {
             Spacer()
 
             Button {
-                showImportSheet = true
+                importPresentation = ImportPresentation(profileSuggestion: nil)
             } label: {
                 Label("Import…", systemImage: "square.and.arrow.down")
             }

--- a/Sources/OnlyEQ/UI/ImportSheet.swift
+++ b/Sources/OnlyEQ/UI/ImportSheet.swift
@@ -5,6 +5,7 @@ import UniformTypeIdentifiers
 struct ImportSheet: View {
     @EnvironmentObject var state: AppState
     @Environment(\.dismiss) private var dismiss
+    let profileSuggestion: ProfileSuggestion?
 
     enum Tab: String, CaseIterable { case drop = "Drop file", paste = "Paste text", browse = "Browse online" }
     @State private var tab: Tab = .drop
@@ -22,6 +23,13 @@ struct ImportSheet: View {
     @State private var selectedEntry: OnlineEntry?
     @State private var previewPreset: EQPreset?
     @State private var isFetchingPreview = false
+    @State private var attemptedAutomaticSelection = false
+
+    init(profileSuggestion: ProfileSuggestion? = nil) {
+        self.profileSuggestion = profileSuggestion
+        _tab = State(initialValue: profileSuggestion == nil ? .drop : .browse)
+        _searchText = State(initialValue: profileSuggestion?.searchQuery ?? "")
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -47,7 +55,10 @@ struct ImportSheet: View {
         }
         .frame(width: 560, height: 470)
         .task(id: source) {
-            if tab == .browse { await state.onlineDB.load(source: source) }
+            if tab == .browse {
+                await state.onlineDB.load(source: source)
+                selectSuggestedResultIfNeeded()
+            }
         }
         .onChange(of: tab) { _, newTab in
             if newTab == .browse { Task { await state.onlineDB.load(source: source) } }
@@ -155,6 +166,23 @@ struct ImportSheet: View {
 
     private var browseTab: some View {
         VStack(spacing: 8) {
+            if let profileSuggestion {
+                HStack(spacing: 7) {
+                    Image(systemName: "headphones.circle.fill").foregroundStyle(Color.accentColor)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("New headphones detected")
+                            .font(.system(size: 11, weight: .semibold))
+                        Text(profileSuggestion.deviceName)
+                            .font(.system(size: 10)).foregroundStyle(.secondary).lineLimit(1)
+                    }
+                    Spacer()
+                    Text("Review before applying")
+                        .font(.system(size: 10)).foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 10).padding(.vertical, 7)
+                .background(RoundedRectangle(cornerRadius: 7).fill(Color.accentColor.opacity(0.09)))
+            }
+
             HStack {
                 Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
                 TextField("Search \(source == .peqdb ? "peqdb" : "AutoEq") headphones…", text: $searchText)
@@ -193,6 +221,24 @@ struct ImportSheet: View {
             let haystack = "\(entry.model) \(entry.reviewer)".lowercased()
             return terms.allSatisfy { haystack.contains($0) }
         }
+    }
+
+    private func selectSuggestedResultIfNeeded() {
+        guard profileSuggestion != nil, !attemptedAutomaticSelection else { return }
+        guard let best = filteredEntries.max(by: {
+            HeadphoneNameMatcher.score(query: searchText, candidate: $0.model)
+                < HeadphoneNameMatcher.score(query: searchText, candidate: $1.model)
+        }) else {
+            if source == .peqdb {
+                source = .autoEq
+            } else {
+                attemptedAutomaticSelection = true
+            }
+            return
+        }
+        attemptedAutomaticSelection = true
+        selectedEntry = best
+        fetchPreview()
     }
 
     private var resultsList: some View {
@@ -306,9 +352,13 @@ struct ImportSheet: View {
             Spacer()
             Button("Cancel") { dismiss() }
                 .keyboardShortcut(.cancelAction)
-            Button("Apply") {
+            Button(profileSuggestion == nil ? "Apply" : "Use for This Device") {
                 if let staged {
-                    state.apply(staged.preset)
+                    if let profileSuggestion {
+                        state.assignSuggestedPreset(staged.preset, to: profileSuggestion)
+                    } else {
+                        state.apply(staged.preset)
+                    }
                     dismiss()
                 }
             }

--- a/Sources/OnlyEQ/UI/SettingsView.swift
+++ b/Sources/OnlyEQ/UI/SettingsView.swift
@@ -22,6 +22,7 @@ struct SettingsView: View {
 // MARK: - General
 
 struct GeneralSettings: View {
+    @EnvironmentObject var state: AppState
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @AppStorage("showLatency") private var showLatency = true
 
@@ -43,6 +44,11 @@ struct GeneralSettings: View {
             Toggle(isOn: $showLatency) {
                 Text("Show latency in popover")
                 Text("Display system audio latency in the popover.")
+            }
+
+            Toggle(isOn: $state.autoSuggestHeadphoneProfiles) {
+                Text("Suggest profiles for new Bluetooth headphones")
+                Text("Open preset search when an unrecognized Bluetooth output becomes active.")
             }
 
             Section {

--- a/Sources/OnlyEQ/main.swift
+++ b/Sources/OnlyEQ/main.swift
@@ -21,7 +21,9 @@ if let flagIndex = CommandLine.arguments.firstIndex(of: "--screenshots") {
 
 // Opens the real editor view for a short, side-effect-free UI profiling run.
 // The engine stays off; the process exits automatically after 15 seconds.
-if CommandLine.arguments.contains("--editor-probe") {
+let editorProbe = CommandLine.arguments.contains("--editor-probe")
+let profileSuggestionProbe = CommandLine.arguments.contains("--profile-suggestion-probe")
+if editorProbe || profileSuggestionProbe {
     MainActor.assumeIsolated {
         AppState.screenshotMode = true
         let app = NSApplication.shared
@@ -39,7 +41,14 @@ if CommandLine.arguments.contains("--editor-probe") {
         )
         window.title = "OnlyEQ UI Probe"
         window.contentViewController = NSHostingController(
-            rootView: EditorView().environmentObject(state)
+            rootView: EditorView(
+                initialImportRequested: profileSuggestionProbe,
+                initialProfileSuggestion: profileSuggestionProbe ? ProfileSuggestion(
+                    deviceUID: "probe.bluetooth.headphones",
+                    deviceName: "Aaron’s WH-1000XM5 Stereo",
+                    searchQuery: "WH-1000XM5"
+                ) : nil
+            ).environmentObject(state)
         )
         window.center()
         window.makeKeyAndOrderFront(nil)

--- a/appcast.xml
+++ b/appcast.xml
@@ -3,22 +3,23 @@
     <channel>
         <title>OnlyEQ</title>
         <item>
-            <title>1.1.2</title>
-            <pubDate>Thu, 09 Jul 2026 12:58:12 -0700</pubDate>
+            <title>1.2.0</title>
+            <pubDate>Thu, 09 Jul 2026 14:41:08 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>6</sparkle:version>
-            <sparkle:shortVersionString>1.1.2</sparkle:shortVersionString>
+            <sparkle:version>7</sparkle:version>
+            <sparkle:shortVersionString>1.2.0</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
-            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.1.2
+            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.0
 
-- Makes the editor spectrum display-linked and smoothly interpolated at 60 fps.
-- Keeps FFT analysis capped at 30 Hz and moves bar drawing into an isolated Core Animation layer, avoiding full SwiftUI editor layout on every frame.
-- Updates the peak meter at 60 Hz using cached text and shape layers, with no redraw when its displayed value is unchanged.
-- Makes EQ node dragging track the pointer immediately while capping model/audio updates at 60 Hz.
-- Coalesces working-preset persistence during dragging and flushes the final value at drag end or app shutdown.
-- Adds a side-effect-free editor profiling mode for performance regression checks.
+- Detects newly active Bluetooth and Bluetooth LE headphones that do not have a device profile.
+- Opens Browse Online automatically with the cleaned device model already searched.
+- Selects and fetches the strongest peqdb match for review, falling back to AutoEq when necessary.
+- Shows the detected device, preset curve, filter count, source, and alternatives before anything is applied.
+- Saves a confirmed preset and remembers it against the stable Core Audio device UID for future connections.
+- Suggests a profile only once per unrecognized device and includes a Settings toggle to disable suggestions.
+- Performs matching only when the output device changes, adding no ongoing audio or visualization CPU work.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.1.2/OnlyEQ.app.zip" length="2362639" type="application/octet-stream" sparkle:edSignature="6QbfYMxm/XLq3FWItD/WOO7ULgO72pfV2QNtAgHsoTjtGKJVgPTFkgq85c/XhmuRyuUrPmxZ4j2NZDTrEHWwAQ=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.0/OnlyEQ.app.zip" length="2410001" type="application/octet-stream" sparkle:edSignature="yojmO4gzXjjSF0R5+G+R9vpSrd0d+yv7PZUN59gOKQUgvpnfVSKzrPOa3h1ztDZZ4Mr4JmjPP6MWBnnSJlYpAg=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.2.0.md
+++ b/release-notes/1.2.0.md
@@ -1,0 +1,9 @@
+# OnlyEQ 1.2.0
+
+- Detects newly active Bluetooth and Bluetooth LE headphones that do not have a device profile.
+- Opens Browse Online automatically with the cleaned device model already searched.
+- Selects and fetches the strongest peqdb match for review, falling back to AutoEq when necessary.
+- Shows the detected device, preset curve, filter count, source, and alternatives before anything is applied.
+- Saves a confirmed preset and remembers it against the stable Core Audio device UID for future connections.
+- Suggests a profile only once per unrecognized device and includes a Settings toggle to disable suggestions.
+- Performs matching only when the output device changes, adding no ongoing audio or visualization CPU work.


### PR DESCRIPTION
## Summary

When a new Bluetooth headphone output becomes active, OnlyEQ now opens its existing online preset browser with the cleaned device name already searched, selects the strongest likely match, and shows the curve for review. Nothing is applied until the user confirms it.

## Why

Per-device profiles are useful only after users discover and assign the correct preset. Core Audio already provides the active device name and stable UID, while OnlyEQ already has peqdb/AutoEq search and profile storage; connecting these pieces removes most of the setup work without introducing silent or risky EQ guesses.

## What

- Detect unprofiled Bluetooth and Bluetooth LE outputs on default-device changes.
- Clean owner prefixes and common Bluetooth noise from device names.
- Open Browse Online with the model query prefilled.
- Rank, select, fetch, and preview the strongest peqdb result; fall back to AutoEq when empty.
- Show a new-headphones explanation and require confirmation.
- Save the confirmed preset and bind it to the stable device UID.
- Suggest only once per unrecognized device, with a Settings opt-out.
- Add a side-effect-free profile-suggestion UI probe and matcher tests.
- Prepare the signed universal 1.2.0 updater artifact.

## Solution

```mermaid
flowchart LR
    Device[Core Audio default-device change] --> Gate{Bluetooth and unprofiled?}
    Gate -->|No| Existing[Existing profile behavior]
    Gate -->|Yes| Clean[Clean device display name]
    Clean --> Search[Open online browser with query]
    Search --> PEQ[Rank peqdb matches]
    PEQ -->|No result| AutoEq[Try AutoEq]
    PEQ --> Preview[Select and fetch best candidate]
    AutoEq --> Preview
    Preview --> Confirm{User confirms?}
    Confirm -->|Yes| Save[Save preset and bind device UID]
    Confirm -->|No| Seen[Remember suggestion was shown]
```

Review order:

1. `Sources/OnlyEQ/App/AppState.swift` — detection gates and assignment behavior.
2. `Sources/OnlyEQ/Models/ProfileSuggestion.swift` — name cleanup and deterministic ranking.
3. `Sources/OnlyEQ/UI/ImportSheet.swift` — searched, selected preview and confirmation UI.
4. `Sources/OnlyEQ/UI/EditorView.swift` and `AppDelegate.swift` — reliable window/sheet request routing.
5. Settings, tests, probe, and release metadata.

## Types of Changes

- [x] User-visible feature
- [x] Device-profile enhancement
- [x] Tests and diagnostics
- [x] Release metadata
- [ ] Breaking change

## Test Plan

- `swift build -c release -Xswiftc -warnings-as-errors`
- `swift run -c release OnlyEQ --test` — 63 checks passed, 0 failed.
- `swift run -c release OnlyEQ --profile-suggestion-probe` — verified through macOS accessibility that `WH-1000XM5` is prefilled, Sony WH-1000XM5 is selected, its 15-filter peqdb preset is fetched, and “Use for This Device” is enabled.
- `codesign --verify --deep --strict --verbose=2 build/OnlyEQ.app`
- `lipo -archs build/OnlyEQ.app/Contents/MacOS/OnlyEQ` — x86_64 arm64.
- `unzip -t build/OnlyEQ.app.zip` — no errors.

## Related Issues

No issue was provided; this implements the requested new-headphone discovery flow.