### PR TITLE
Remove volume lag and focus windows reliably

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ swift run OnlyEQ --editor-probe       # 15-second editor UI profiling run
 swift run OnlyEQ --profile-suggestion-probe # previews Bluetooth profile discovery
 swift run OnlyEQ --screenshots out/   # renders the README screenshots
 ./scripts/build-app.sh release        # universal binary release build
-./scripts/prepare-release.sh 1.2.0    # signed archive + appcast
+./scripts/prepare-release.sh 1.2.1    # signed archive + appcast
 ```
 
 Tests run inside the binary because the Command Line Tools don't ship XCTest. Diagnostics land in `~/Library/Logs/OnlyEQ.log`.

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleExecutable</key>
 	<string>OnlyEQ</string>
 	<key>CFBundlePackageType</key>

--- a/Sources/OnlyEQ/App/AppDelegate.swift
+++ b/Sources/OnlyEQ/App/AppDelegate.swift
@@ -73,8 +73,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             popover.performClose(nil)
         } else {
             AppState.shared.refreshDevices()
-            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             NSApp.activate(ignoringOtherApps: true)
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            popover.contentViewController?.view.window?.makeKey()
         }
     }
 
@@ -219,8 +220,7 @@ final class WindowManager {
             }
             editorWindow = window
         }
-        editorWindow?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        if let editorWindow { focus(editorWindow) }
         if importing, !isCreatingWindow {
             EditorView.importRequested.send(profileSuggestion)
         }
@@ -241,8 +241,7 @@ final class WindowManager {
             window.center()
             settingsWindow = window
         }
-        settingsWindow?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        if let settingsWindow { focus(settingsWindow) }
     }
 
     func showOnboarding() {
@@ -260,11 +259,25 @@ final class WindowManager {
             window.center()
             onboardingWindow = window
         }
-        onboardingWindow?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        if let onboardingWindow { focus(onboardingWindow) }
     }
 
     func closeOnboarding() {
         onboardingWindow?.close()
+    }
+
+    /// Accessory/menu-bar apps must activate before asking a window to become
+    /// key. Retry on the next run-loop turn because a closing transient popover
+    /// can otherwise return focus to the previous application.
+    private func focus(_ window: NSWindow) {
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
+        DispatchQueue.main.async { [weak window] in
+            guard let window, window.isVisible else { return }
+            if !NSApp.isActive || !window.isKeyWindow {
+                NSApp.activate(ignoringOtherApps: true)
+                window.makeKeyAndOrderFront(nil)
+            }
+        }
     }
 }

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -16,6 +16,7 @@ final class AppState: ObservableObject {
     let engine = ProcessTapEngine()
     let store = PresetStore()
     let onlineDB = OnlineDatabase()
+    private let hardwareVolumeWriter = HardwareVolumeWriter()
 
     /// Installed by the app delegate so device detection can request UI without
     /// coupling the audio/state layer to a particular window implementation.
@@ -98,6 +99,8 @@ final class AppState: ObservableObject {
     private var silenceCheckTimer: Timer?
     private var pendingPresetPersistence: DispatchWorkItem?
     private var suggestedDeviceUIDs = Set(UserDefaults.standard.stringArray(forKey: "profileSuggestion.seenDeviceUIDs") ?? [])
+    private var currentDeviceHasHardwareVolume = false
+    private var lastPushedSoftwareGainDB = Double.nan
 
     /// Sticky per-session flag: once the tap has delivered audio we know the
     /// permission is granted, so engine restarts (device switches, settings
@@ -133,14 +136,16 @@ final class AppState: ObservableObject {
     }
 
     private func pushToProcessor() {
+        let outputGainDB = softwareGainDB
         engine.processor.update(
             bands: preset.bands,
             preampDB: effectivePreampDB,
-            outputGainDB: softwareGainDB,
+            outputGainDB: outputGainDB,
             limiterEnabled: limiterEnabled,
             limiterCeilingDB: limiterCeilingDB,
             bypassed: bypassed || !isEnabled
         )
+        lastPushedSoftwareGainDB = outputGainDB
     }
 
     /// Keep visualization work off the realtime thread unless a consumer is
@@ -296,20 +301,31 @@ final class AppState: ObservableObject {
     }
 
     private var hasHardwareVolume: Bool {
-        guard let device = currentDevice else { return false }
-        return AudioDeviceManager.hardwareVolume(device.id) != nil
+        currentDeviceHasHardwareVolume
     }
 
     private func applyVolume() {
         guard !Self.screenshotMode, let device = currentDevice else { return }
         if hasHardwareVolume {
-            AudioDeviceManager.setHardwareVolume(device.id, Float(min(volumePercent, 100) / 100))
+            hardwareVolumeWriter.submit(deviceID: device.id,
+                                        volume: Float(min(volumePercent, 100) / 100))
         }
-        pushToProcessor()
+        let outputGainDB = softwareGainDB
+        if !outputGainDB.isApproximatelyEqual(to: lastPushedSoftwareGainDB) {
+            pushToProcessor()
+        }
     }
 
     private func syncVolumeFromDevice() {
-        guard let device = currentDevice, let hw = AudioDeviceManager.hardwareVolume(device.id) else { return }
+        guard let device = currentDevice else {
+            currentDeviceHasHardwareVolume = false
+            return
+        }
+        guard let hw = AudioDeviceManager.hardwareVolume(device.id) else {
+            currentDeviceHasHardwareVolume = false
+            return
+        }
+        currentDeviceHasHardwareVolume = true
         // Only reflect hardware volume when we're not boosting.
         if volumePercent <= 100 {
             let percent = Double(hw) * 100
@@ -349,5 +365,11 @@ final class AppState: ObservableObject {
            let saved = try? JSONDecoder().decode(EQPreset.self, from: data) {
             preset = saved
         }
+    }
+}
+
+private extension Double {
+    func isApproximatelyEqual(to other: Double) -> Bool {
+        isFinite && other.isFinite && abs(self - other) < 0.000_001
     }
 }

--- a/Sources/OnlyEQ/Audio/HardwareVolumeWriter.swift
+++ b/Sources/OnlyEQ/Audio/HardwareVolumeWriter.swift
@@ -1,0 +1,44 @@
+import CoreAudio
+import Foundation
+
+/// Core Audio property writes can block briefly, especially for Bluetooth
+/// devices. Keep them off the main actor and retain only the newest request so
+/// a fast pointer drag never creates a queue of stale volume changes.
+final class HardwareVolumeWriter: @unchecked Sendable {
+    private struct Request: Sendable {
+        var deviceID: AudioObjectID
+        var volume: Float
+    }
+
+    private let lock = NSLock()
+    private let queue = DispatchQueue(label: "OnlyEQ.hardware-volume", qos: .userInteractive)
+    private var pending: Request?
+    private var workerIsRunning = false
+
+    func submit(deviceID: AudioObjectID, volume: Float) {
+        lock.lock()
+        pending = Request(deviceID: deviceID, volume: volume)
+        let shouldStart = !workerIsRunning
+        if shouldStart { workerIsRunning = true }
+        lock.unlock()
+
+        if shouldStart {
+            queue.async { [self] in drain() }
+        }
+    }
+
+    private func drain() {
+        while true {
+            lock.lock()
+            guard let request = pending else {
+                workerIsRunning = false
+                lock.unlock()
+                return
+            }
+            pending = nil
+            lock.unlock()
+
+            AudioDeviceManager.setHardwareVolume(request.deviceID, request.volume)
+        }
+    }
+}

--- a/Sources/OnlyEQ/UI/PopoverView.swift
+++ b/Sources/OnlyEQ/UI/PopoverView.swift
@@ -272,23 +272,26 @@ struct PopoverView: View {
 struct BoostSlider: View {
     @Binding var value: Double
     var maxPercent: Double
+    @State private var trackedValue: Double?
+    @State private var lastPublishedTime: TimeInterval = 0
 
     var body: some View {
+        let displayedValue = trackedValue ?? value
         VStack(spacing: 3) {
             HStack(spacing: 8) {
-                Image(systemName: value == 0 ? "speaker.slash.fill" : "speaker.wave.2.fill")
+                Image(systemName: displayedValue == 0 ? "speaker.slash.fill" : "speaker.wave.2.fill")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                     .frame(width: 16)
                 GeometryReader { geo in
                     let width = geo.size.width
-                    let fraction = min(max(value / maxPercent, 0), 1)
+                    let fraction = min(max(displayedValue / maxPercent, 0), 1)
                     let hundred = min(100 / maxPercent, 1)
                     ZStack(alignment: .leading) {
                         Capsule().fill(Color.primary.opacity(0.12)).frame(height: 5)
                         Capsule().fill(Color.accentColor)
                             .frame(width: min(fraction, hundred) * width, height: 5)
-                        if value > 100 {
+                        if displayedValue > 100 {
                             Rectangle().fill(.orange)
                                 .frame(width: (fraction - hundred) * width, height: 5)
                                 .offset(x: hundred * width)
@@ -308,9 +311,22 @@ struct BoostSlider: View {
                     }
                     .frame(maxHeight: .infinity)
                     .contentShape(Rectangle())
-                    .gesture(DragGesture(minimumDistance: 0).onChanged { g in
-                        value = min(max(Double((g.location.x - 7.5) / (width - 15)) * maxPercent, 0), maxPercent)
-                    })
+                    .gesture(DragGesture(minimumDistance: 0)
+                        .onChanged { gesture in
+                            let updated = sliderValue(at: gesture.location.x, width: width)
+                            trackedValue = updated
+                            let now = ProcessInfo.processInfo.systemUptime
+                            if lastPublishedTime == 0 || now - lastPublishedTime >= 1.0 / 60.0 {
+                                value = updated
+                                lastPublishedTime = now
+                            }
+                        }
+                        .onEnded { gesture in
+                            let updated = sliderValue(at: gesture.location.x, width: width)
+                            value = updated
+                            trackedValue = nil
+                            lastPublishedTime = 0
+                        })
                 }
                 .frame(height: 18)
             }
@@ -328,6 +344,11 @@ struct BoostSlider: View {
             .frame(height: 11)
             .padding(.leading, 24)
         }
+    }
+
+    private func sliderValue(at x: CGFloat, width: CGFloat) -> Double {
+        guard width > 15 else { return value }
+        return min(max(Double((x - 7.5) / (width - 15)) * maxPercent, 0), maxPercent)
     }
 }
 

--- a/appcast.xml
+++ b/appcast.xml
@@ -3,23 +3,22 @@
     <channel>
         <title>OnlyEQ</title>
         <item>
-            <title>1.2.0</title>
-            <pubDate>Thu, 09 Jul 2026 14:41:08 -0700</pubDate>
+            <title>1.2.1</title>
+            <pubDate>Thu, 09 Jul 2026 18:43:50 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>7</sparkle:version>
-            <sparkle:shortVersionString>1.2.0</sparkle:shortVersionString>
+            <sparkle:version>8</sparkle:version>
+            <sparkle:shortVersionString>1.2.1</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
-            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.0
+            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.1
 
-- Detects newly active Bluetooth and Bluetooth LE headphones that do not have a device profile.
-- Opens Browse Online automatically with the cleaned device model already searched.
-- Selects and fetches the strongest peqdb match for review, falling back to AutoEq when necessary.
-- Shows the detected device, preset curve, filter count, source, and alternatives before anything is applied.
-- Saves a confirmed preset and remembers it against the stable Core Audio device UID for future connections.
-- Suggests a profile only once per unrecognized device and includes a Settings toggle to disable suggestions.
-- Performs matching only when the output device changes, adding no ongoing audio or visualization CPU work.
+- Makes the boost-volume thumb track pointer movement locally at full input rate while publishing state at the display rate.
+- Moves potentially blocking Core Audio hardware-volume writes off the main thread.
+- Coalesces pending Bluetooth volume changes so slow hardware never builds a backlog of stale values.
+- Avoids rebuilding the audio DSP snapshot for ordinary hardware-volume changes below 100%.
+- Activates the menu-bar app before presenting its popover, editor, settings, or onboarding windows.
+- Reasserts key-window focus after a transient popover closes, preventing inactive white/washed-out window styling until the first click.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.0/OnlyEQ.app.zip" length="2410001" type="application/octet-stream" sparkle:edSignature="yojmO4gzXjjSF0R5+G+R9vpSrd0d+yv7PZUN59gOKQUgvpnfVSKzrPOa3h1ztDZZ4Mr4JmjPP6MWBnnSJlYpAg=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.1/OnlyEQ.app.zip" length="2416446" type="application/octet-stream" sparkle:edSignature="ZR/84gn8RhL0UcaMJz4992+BpXI6+G1NuR1JQLLlfZF0mIkUnRhXFS1ct1YxaeB7CtzFULSj9PArUn1jHr+iCA=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.2.1.md
+++ b/release-notes/1.2.1.md
@@ -1,0 +1,8 @@
+# OnlyEQ 1.2.1
+
+- Makes the boost-volume thumb track pointer movement locally at full input rate while publishing state at the display rate.
+- Moves potentially blocking Core Audio hardware-volume writes off the main thread.
+- Coalesces pending Bluetooth volume changes so slow hardware never builds a backlog of stale values.
+- Avoids rebuilding the audio DSP snapshot for ordinary hardware-volume changes below 100%.
+- Activates the menu-bar app before presenting its popover, editor, settings, or onboarding windows.
+- Reasserts key-window focus after a transient popover closes, preventing inactive white/washed-out window styling until the first click.


### PR DESCRIPTION
## Summary

Volume dragging now remains attached to the pointer even when Bluetooth hardware-volume writes are slow, and OnlyEQ windows become active/key as soon as they appear instead of looking washed out until the first click.

## Why

Every slider event previously performed synchronous Core Audio property reads/writes and rebuilt the processor snapshot on the main actor. Accessory-app windows were also ordered front before OnlyEQ was activated, allowing macOS to render them with inactive styling.

## What

- Track the boost thumb locally at pointer rate and publish at 60 Hz.
- Cache hardware-volume capability instead of querying it on every drag event.
- Move Core Audio property writes to a user-interactive serial worker.
- Coalesce pending requests so only the newest Bluetooth volume survives a slow write.
- Skip DSP snapshot rebuilds for hardware-only changes below 100%.
- Activate OnlyEQ before showing its popover or windows.
- Reassert key focus on the next run-loop turn after transient popovers close.
- Prepare the signed universal 1.2.1 updater artifact.

## Solution

```mermaid
flowchart LR
    Pointer[Pointer events] --> Thumb[Local thumb state]
    Thumb -->|max 60 Hz| AppState[Published volume]
    AppState --> Hardware{Hardware volume?}
    Hardware -->|Yes| Latest[Replace pending request]
    Latest --> Worker[Background Core Audio writer]
    Hardware -->|Boost or software-only| DSP[Update DSP gain snapshot]
    Open[Open popover or window] --> Activate[Activate accessory app]
    Activate --> Key[Make window key and front]
    Key --> Retry[Next-turn focus verification]
```

Review order:

1. `Sources/OnlyEQ/UI/PopoverView.swift` — local drag behavior and 60 Hz publication.
2. `Sources/OnlyEQ/Audio/HardwareVolumeWriter.swift` — nonblocking latest-value writer.
3. `Sources/OnlyEQ/App/AppState.swift` — capability caching and selective DSP updates.
4. `Sources/OnlyEQ/App/AppDelegate.swift` — activation/key-window ordering.
5. Release metadata.

## Types of Changes

- [x] Bug fix
- [x] Performance improvement
- [x] Release metadata
- [ ] Breaking change

## Test Plan

- `swift build -c release -Xswiftc -warnings-as-errors`
- `swift run -c release OnlyEQ --test` — 63 checks passed, 0 failed.
- `codesign --verify --deep --strict --verbose=2 build/OnlyEQ.app`
- `lipo -archs build/OnlyEQ.app/Contents/MacOS/OnlyEQ` — x86_64 arm64.
- `unzip -t build/OnlyEQ.app.zip` — no errors.

## Related Issues

No issue was provided; this follows the reported laggy volume control and inactive white window styling.