### PR TITLE
Open the menu bar popover instantly

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ swift run OnlyEQ --editor-probe       # 15-second editor UI profiling run
 swift run OnlyEQ --profile-suggestion-probe # previews Bluetooth profile discovery
 swift run OnlyEQ --screenshots out/   # renders the README screenshots
 ./scripts/build-app.sh release        # universal binary release build
-./scripts/prepare-release.sh 1.2.1    # signed archive + appcast
+./scripts/prepare-release.sh 1.2.2    # signed archive + appcast
 ```
 
 Tests run inside the binary because the Command Line Tools don't ship XCTest. Diagnostics land in `~/Library/Logs/OnlyEQ.log`.

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.2.2</string>
 	<key>CFBundleExecutable</key>
 	<string>OnlyEQ</string>
 	<key>CFBundlePackageType</key>

--- a/Sources/OnlyEQ/App/AppDelegate.swift
+++ b/Sources/OnlyEQ/App/AppDelegate.swift
@@ -25,6 +25,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
         popover = NSPopover()
         popover.behavior = .transient
+        popover.animates = false
         popover.delegate = self
         let hosting = NSHostingController(rootView: PopoverView().environmentObject(state))
         // PopoverView has a stable frame, so size the popover once. Continuously

--- a/appcast.xml
+++ b/appcast.xml
@@ -3,22 +3,18 @@
     <channel>
         <title>OnlyEQ</title>
         <item>
-            <title>1.2.1</title>
-            <pubDate>Thu, 09 Jul 2026 18:43:50 -0700</pubDate>
+            <title>1.2.2</title>
+            <pubDate>Thu, 09 Jul 2026 18:46:41 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>8</sparkle:version>
-            <sparkle:shortVersionString>1.2.1</sparkle:shortVersionString>
+            <sparkle:version>9</sparkle:version>
+            <sparkle:shortVersionString>1.2.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
-            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.1
+            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.2
 
-- Makes the boost-volume thumb track pointer movement locally at full input rate while publishing state at the display rate.
-- Moves potentially blocking Core Audio hardware-volume writes off the main thread.
-- Coalesces pending Bluetooth volume changes so slow hardware never builds a backlog of stale values.
-- Avoids rebuilding the audio DSP snapshot for ordinary hardware-volume changes below 100%.
-- Activates the menu-bar app before presenting its popover, editor, settings, or onboarding windows.
-- Reasserts key-window focus after a transient popover closes, preventing inactive white/washed-out window styling until the first click.
+- Removes the menu-bar popover opening and closing animation.
+- Makes the OnlyEQ panel appear immediately and accept input as soon as the menu-bar icon is clicked.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.1/OnlyEQ.app.zip" length="2416446" type="application/octet-stream" sparkle:edSignature="ZR/84gn8RhL0UcaMJz4992+BpXI6+G1NuR1JQLLlfZF0mIkUnRhXFS1ct1YxaeB7CtzFULSj9PArUn1jHr+iCA=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.2/OnlyEQ.app.zip" length="2416619" type="application/octet-stream" sparkle:edSignature="/KE0na1hEcYxEx/ih8PAD2m43C5HIqsXEzBywYtZXnDzRrVvWaOQgAMSt8Nnp4qgHlo5LSzoZ1djqgZB5jX7Cw=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.2.2.md
+++ b/release-notes/1.2.2.md
@@ -1,0 +1,4 @@
+# OnlyEQ 1.2.2
+
+- Removes the menu-bar popover opening and closing animation.
+- Makes the OnlyEQ panel appear immediately and accept input as soon as the menu-bar icon is clicked.


### PR DESCRIPTION
## Summary

OnlyEQ now appears immediately when its menu-bar icon is clicked, without the standard popover opening or closing animation.

## Why

The animation adds perceived latency to a utility panel that is opened frequently and is expected to be immediately interactive.

## What

- Disable `NSPopover` animation for both presentation and dismissal.
- Prepare the signed universal 1.2.2 updater artifact.

## Solution

```mermaid
flowchart LR
    Click[Menu-bar click] --> Activate[Activate OnlyEQ]
    Activate --> Show[Show nonanimated popover]
    Show --> Input[Panel immediately accepts input]
```

Review order:

1. `Sources/OnlyEQ/App/AppDelegate.swift` — the behavior change.
2. Release metadata and notes.

## Types of Changes

- [x] User-visible enhancement
- [x] Release metadata
- [ ] Breaking change

## Test Plan

- `swift build -c release -Xswiftc -warnings-as-errors`
- `swift run -c release OnlyEQ --test` — 63 checks passed, 0 failed.
- `codesign --verify --deep --strict --verbose=2 build/OnlyEQ.app`
- `lipo -archs build/OnlyEQ.app/Contents/MacOS/OnlyEQ` — x86_64 arm64.
- `unzip -t build/OnlyEQ.app.zip` — no errors.

## Related Issues

No issue was provided; this implements the requested instant menu-bar panel.