### PR TITLE
Replace the pointed popover with an arrowless panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ swift run OnlyEQ --test               # self-test suite (importer + DSP)
 swift run OnlyEQ --engine-probe       # headless engine check, prints JSON
 swift run OnlyEQ --editor-probe       # 15-second editor UI profiling run
 swift run OnlyEQ --profile-suggestion-probe # previews Bluetooth profile discovery
+swift run OnlyEQ --menu-panel-probe    # previews the arrowless menu panel
 swift run OnlyEQ --screenshots out/   # renders the README screenshots
 ./scripts/build-app.sh release        # universal binary release build
 ./scripts/prepare-release.sh 1.2.2    # signed archive + appcast

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.2.2</string>
 	<key>CFBundleExecutable</key>

--- a/Sources/OnlyEQ/App/AppDelegate.swift
+++ b/Sources/OnlyEQ/App/AppDelegate.swift
@@ -6,7 +6,7 @@ import Sparkle
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var statusItem: NSStatusItem!
-    private var popover: NSPopover!
+    private var menuPanel: MenuPanel!
     private let updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
         updaterDelegate: nil,
@@ -23,18 +23,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
         Log.write("app: state ready")
 
-        popover = NSPopover()
-        popover.behavior = .transient
-        popover.animates = false
-        popover.delegate = self
-        let hosting = NSHostingController(rootView: PopoverView().environmentObject(state))
-        // PopoverView has a stable frame, so size the popover once. Continuously
-        // publishing preferredContentSize makes every spectrum tick remeasure
-        // and lay out the entire popover instead of redrawing just its Canvas.
+        let hosting = NSHostingController(
+            rootView: PopoverView()
+                .environmentObject(state)
+                .background(Color(nsColor: .windowBackgroundColor))
+        )
         hosting.sizingOptions = .standardBounds
-        popover.contentViewController = hosting
-        popover.contentSize = hosting.view.fittingSize
-        Log.write("app: popover ready")
+        menuPanel = MenuPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 410),
+            styleMask: [.borderless], backing: .buffered, defer: false
+        )
+        menuPanel.contentViewController = hosting
+        menuPanel.delegate = self
+        menuPanel.level = .popUpMenu
+        menuPanel.isFloatingPanel = true
+        menuPanel.hidesOnDeactivate = true
+        menuPanel.isReleasedWhenClosed = false
+        menuPanel.hasShadow = true
+        menuPanel.isOpaque = false
+        menuPanel.backgroundColor = .clear
+        menuPanel.collectionBehavior = [.transient, .moveToActiveSpace, .fullScreenAuxiliary]
+        hosting.view.wantsLayer = true
+        hosting.view.layer?.cornerRadius = 12
+        hosting.view.layer?.cornerCurve = .continuous
+        hosting.view.layer?.masksToBounds = true
+        Log.write("app: menu panel ready")
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem.button {
@@ -44,6 +57,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         }
         Log.write("app: status item ready (visible: \(statusItem.isVisible))")
+
+        if CommandLine.arguments.contains("--menu-panel-probe") {
+            DispatchQueue.main.async { [weak self] in self?.togglePopover() }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 15) { NSApp.terminate(nil) }
+        }
 
         HotKeyManager.shared.install()
 
@@ -70,17 +88,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     private func togglePopover() {
         guard let button = statusItem.button else { return }
-        if popover.isShown {
-            popover.performClose(nil)
+        if menuPanel.isVisible {
+            hideMenuPanel()
         } else {
             AppState.shared.refreshDevices()
+            positionMenuPanel(below: button)
             NSApp.activate(ignoringOtherApps: true)
-            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-            popover.contentViewController?.view.window?.makeKey()
+            menuPanel.makeKeyAndOrderFront(nil)
+            AppState.shared.popoverIsVisible = true
         }
     }
 
+    private func positionMenuPanel(below button: NSStatusBarButton) {
+        guard let buttonWindow = button.window else { return }
+        let buttonInWindow = button.convert(button.bounds, to: nil)
+        let buttonOnScreen = buttonWindow.convertToScreen(buttonInWindow)
+        let screenFrame = buttonWindow.screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? .zero
+        let panelSize = menuPanel.frame.size
+        let x = min(max(buttonOnScreen.midX - panelSize.width / 2, screenFrame.minX + 6),
+                    screenFrame.maxX - panelSize.width - 6)
+        let y = buttonOnScreen.minY - panelSize.height - 4
+        menuPanel.setFrameOrigin(NSPoint(x: x, y: max(y, screenFrame.minY + 6)))
+    }
+
+    private func hideMenuPanel() {
+        guard menuPanel.isVisible else { return }
+        menuPanel.orderOut(nil)
+        AppState.shared.popoverIsVisible = false
+    }
+
     private func showContextMenu() {
+        hideMenuPanel()
         let state = AppState.shared
         let menu = NSMenu()
 
@@ -165,18 +203,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     @objc private func checkForUpdates() { updaterController.checkForUpdates(nil) }
 }
 
-// Closing the popover only orders its window out — the hosting controller
-// (and the SwiftUI tree inside) stays alive, so PopoverView gates its
-// spectrum animation on this visibility flag to stop it from refreshing
-// forever after the first show.
-extension AppDelegate: NSPopoverDelegate {
-    func popoverDidShow(_ notification: Notification) {
-        AppState.shared.popoverIsVisible = true
+extension AppDelegate: NSWindowDelegate {
+    func windowDidResignKey(_ notification: Notification) {
+        guard notification.object as? NSWindow === menuPanel else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self, !self.menuPanel.isKeyWindow else { return }
+            self.hideMenuPanel()
+        }
     }
+}
 
-    func popoverDidClose(_ notification: Notification) {
-        AppState.shared.popoverIsVisible = false
-    }
+/// Borderless AppKit windows do not normally become key. This tiny subclass
+/// gives the arrowless menu panel normal control focus and active appearance.
+private final class MenuPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
 }
 
 /// Owns the editor, settings, and onboarding windows.

--- a/Sources/OnlyEQ/main.swift
+++ b/Sources/OnlyEQ/main.swift
@@ -88,6 +88,9 @@ if CommandLine.arguments.contains("--engine-probe") {
 }
 
 MainActor.assumeIsolated {
+    if CommandLine.arguments.contains("--menu-panel-probe") {
+        AppState.screenshotMode = true
+    }
     let app = NSApplication.shared
     let delegate = AppDelegate()
     app.delegate = delegate

--- a/appcast.xml
+++ b/appcast.xml
@@ -4,17 +4,18 @@
         <title>OnlyEQ</title>
         <item>
             <title>1.2.2</title>
-            <pubDate>Thu, 09 Jul 2026 18:46:41 -0700</pubDate>
+            <pubDate>Thu, 09 Jul 2026 18:53:20 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>9</sparkle:version>
+            <sparkle:version>10</sparkle:version>
             <sparkle:shortVersionString>1.2.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
             <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.2
 
 - Removes the menu-bar popover opening and closing animation.
+- Replaces the pointed popover shell with a rounded, arrowless menu panel.
 - Makes the OnlyEQ panel appear immediately and accept input as soon as the menu-bar icon is clicked.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.2/OnlyEQ.app.zip" length="2416619" type="application/octet-stream" sparkle:edSignature="/KE0na1hEcYxEx/ih8PAD2m43C5HIqsXEzBywYtZXnDzRrVvWaOQgAMSt8Nnp4qgHlo5LSzoZ1djqgZB5jX7Cw=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.2/OnlyEQ.app.zip" length="2424654" type="application/octet-stream" sparkle:edSignature="rzzLrivbOOmq8agY/F4TbJE5Je9eXKAMhZtDnmbOhBNpmdPL0gv0Kax02ZxiQ3fMNjnl0YI1DNvr+x4YijawDA=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.2.2.md
+++ b/release-notes/1.2.2.md
@@ -1,4 +1,5 @@
 # OnlyEQ 1.2.2
 
 - Removes the menu-bar popover opening and closing animation.
+- Replaces the pointed popover shell with a rounded, arrowless menu panel.
 - Makes the OnlyEQ panel appear immediately and accept input as soon as the menu-bar icon is clicked.


### PR DESCRIPTION
## Summary

The menu-bar interface now appears as a clean rounded panel without the popover triangle or any opening animation. It retains immediate keyboard/control focus, menu behavior, outside-click dismissal, and positioning beneath the status icon.

## Why

`NSPopover` always supplies a directional arrow. Removing that visual requires a custom panel shell rather than another styling flag, and the result should behave like the compact window the user requested.

## What

- Replace `NSPopover` with a borderless, key-capable `NSPanel`.
- Position it directly under and centered on the menu-bar icon.
- Clamp it to the active screen edges.
- Preserve rounded corners, shadow, active styling, transient dismissal, and Space/full-screen behavior.
- Keep visibility gating for spectrum CPU usage.
- Add a side-effect-free menu-panel UI probe.
- Update the existing 1.2.2 release to build 10 instead of creating another semantic version.

## Solution

```mermaid
flowchart LR
    Click[Menu-bar click] --> Position[Position below status icon]
    Position --> Activate[Activate OnlyEQ]
    Activate --> Panel[Show borderless key panel]
    Panel --> Controls[Immediate focused controls]
    Panel --> Resign[Resign key or deactivate]
    Resign --> Hide[Hide panel and stop visualization]
```

Review order:

1. `Sources/OnlyEQ/App/AppDelegate.swift` — panel construction, positioning, focus, and dismissal.
2. `Sources/OnlyEQ/main.swift` — UI regression probe setup.
3. Release metadata and notes.

## Types of Changes

- [x] User-visible enhancement
- [x] UI architecture change
- [x] Release metadata
- [ ] Breaking change

## Test Plan

- `swift build -c release -Xswiftc -warnings-as-errors`
- `swift run -c release OnlyEQ --test` — 63 checks passed, 0 failed.
- `swift run -c release OnlyEQ --menu-panel-probe` — visually verified rounded arrowless panel, immediate focus, correct positioning, and working device menu.
- `codesign --verify --deep --strict --verbose=2 build/OnlyEQ.app`
- `lipo -archs build/OnlyEQ.app/Contents/MacOS/OnlyEQ` — x86_64 arm64.
- `unzip -t build/OnlyEQ.app.zip` — no errors.

## Related Issues

No issue was provided; this implements the requested normal arrowless panel while retaining version 1.2.2.