### PR TITLE
Keep the status icon highlighted while the panel is open

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.2.2</string>
 	<key>CFBundleExecutable</key>

--- a/Sources/OnlyEQ/App/AppDelegate.swift
+++ b/Sources/OnlyEQ/App/AppDelegate.swift
@@ -95,6 +95,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             positionMenuPanel(below: button)
             NSApp.activate(ignoringOtherApps: true)
             menuPanel.makeKeyAndOrderFront(nil)
+            button.highlight(true)
+            // Reassert after the status button finishes its mouse-up tracking;
+            // AppKit otherwise clears the pressed highlight when the action returns.
+            DispatchQueue.main.async { [weak self, weak button] in
+                guard let self, self.menuPanel.isVisible else { return }
+                button?.highlight(true)
+            }
             AppState.shared.popoverIsVisible = true
         }
     }
@@ -112,8 +119,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     private func hideMenuPanel() {
-        guard menuPanel.isVisible else { return }
-        menuPanel.orderOut(nil)
+        statusItem.button?.highlight(false)
+        if menuPanel.isVisible { menuPanel.orderOut(nil) }
         AppState.shared.popoverIsVisible = false
     }
 

--- a/appcast.xml
+++ b/appcast.xml
@@ -4,9 +4,9 @@
         <title>OnlyEQ</title>
         <item>
             <title>1.2.2</title>
-            <pubDate>Thu, 09 Jul 2026 18:53:20 -0700</pubDate>
+            <pubDate>Thu, 09 Jul 2026 18:57:40 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>10</sparkle:version>
+            <sparkle:version>11</sparkle:version>
             <sparkle:shortVersionString>1.2.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
             <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.2
@@ -14,8 +14,9 @@
 - Removes the menu-bar popover opening and closing animation.
 - Replaces the pointed popover shell with a rounded, arrowless menu panel.
 - Makes the OnlyEQ panel appear immediately and accept input as soon as the menu-bar icon is clicked.
+- Keeps the menu-bar icon brightly highlighted while the panel is open.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.2/OnlyEQ.app.zip" length="2424654" type="application/octet-stream" sparkle:edSignature="rzzLrivbOOmq8agY/F4TbJE5Je9eXKAMhZtDnmbOhBNpmdPL0gv0Kax02ZxiQ3fMNjnl0YI1DNvr+x4YijawDA=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.2/OnlyEQ.app.zip" length="2425878" type="application/octet-stream" sparkle:edSignature="hjvWngeWdI4XZ1it3UE0UITWjsUQpvtiwJhY/NfiYx5E/FIBQBQRMg40bTLLPxxvUq4pgrFmZDbGnvIsigGAAQ=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.2.2.md
+++ b/release-notes/1.2.2.md
@@ -3,3 +3,4 @@
 - Removes the menu-bar popover opening and closing animation.
 - Replaces the pointed popover shell with a rounded, arrowless menu panel.
 - Makes the OnlyEQ panel appear immediately and accept input as soon as the menu-bar icon is clicked.
+- Keeps the menu-bar icon brightly highlighted while the panel is open.


### PR DESCRIPTION
## Summary

The OnlyEQ menu-bar icon now remains in its bright highlighted state for the entire time the arrowless panel is open, then returns to its normal appearance when the panel closes.

## Why

Replacing `NSPopover` removed the automatic persistent status-button highlight. AppKit also clears a programmatic highlight after mouse-up tracking, so the panel needs to reassert it on the next run-loop turn.

## What

- Highlight the status button when the menu panel opens.
- Reassert the highlight after mouse-up tracking completes.
- Clear it reliably on every panel dismissal path, including automatic deactivation.
- Update the existing 1.2.2 release to build 11 rather than creating another semantic version.

## Solution

```mermaid
flowchart LR
    Open[Panel opens] --> Highlight[Highlight status button]
    Highlight --> Reassert[Reassert after mouse-up]
    Reassert --> Visible[Remain bright while visible]
    Close[Panel closes or deactivates] --> Clear[Clear highlight]
```

Review order:

1. `Sources/OnlyEQ/App/AppDelegate.swift` — highlight lifecycle.
2. Release metadata and notes.

## Types of Changes

- [x] User-visible enhancement
- [x] Release metadata
- [ ] Breaking change

## Test Plan

- `swift build -c release -Xswiftc -warnings-as-errors`
- `swift run -c release OnlyEQ --test` — 63 checks passed, 0 failed.
- `swift run -c release OnlyEQ --menu-panel-probe` — verified the bright status-button pill remains while the panel is open.
- `codesign --verify --deep --strict --verbose=2 build/OnlyEQ.app`
- `unzip -t build/OnlyEQ.app.zip` — no errors.

## Related Issues

No issue was provided; this implements the requested persistent white-ish open-state icon while retaining version 1.2.2.