### PR TITLE
Rebuild the engine when the device sample rate changes

### DIFF
--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -116,6 +116,12 @@ final class AppState: ObservableObject {
         engine.onStateChange = { [weak self] state in
             Task { @MainActor in self?.engineState = state }
         }
+        // A nominal sample-rate change (Bluetooth codec renegotiation, Audio
+        // MIDI Setup) invalidates the biquad coefficients; rebuild everything
+        // at the new rate.
+        engine.onSampleRateChange = { [weak self] in
+            Task { @MainActor in self?.rebuildEngine() }
+        }
         rebuildEngine()
         startSilenceWatchdog()
     }

--- a/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
+++ b/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
@@ -35,6 +35,7 @@ final class ProcessTapEngine {
     private var tapID: AudioObjectID = 0
     private var aggregateID: AudioObjectID = 0
     private var ioProcID: AudioDeviceIOProcID?
+    private var sampleRateListener: AudioObjectPropertyListenerBlock?
     private var channelScratch: [UnsafeMutablePointer<Float>] = []
     private struct InputChannel {
         var pointer: UnsafeMutablePointer<Float>
@@ -44,6 +45,11 @@ final class ProcessTapEngine {
     private var activeChannels: [UnsafeMutablePointer<Float>] = []
 
     var onStateChange: ((State) -> Void)?
+
+    /// Fired (on the main queue) when the tapped device's nominal sample rate
+    /// changes while running. Biquad coefficients are baked for one rate, so
+    /// the owner must restart the engine to stay on pitch.
+    var onSampleRateChange: (() -> Void)?
 
     init() {
         inputChannels.reserveCapacity(8)
@@ -147,10 +153,12 @@ final class ProcessTapEngine {
             return
         }
 
+        installSampleRateListener(on: deviceID)
         transition(to: .running)
     }
 
     func stop() {
+        removeSampleRateListener()
         if let ioProcID, aggregateID != 0 {
             AudioDeviceStop(aggregateID, ioProcID)
             AudioDeviceDestroyIOProcID(aggregateID, ioProcID)
@@ -185,6 +193,30 @@ final class ProcessTapEngine {
         Log.write("engine: \(newState)")
         let callback = onStateChange
         DispatchQueue.main.async { callback?(newState) }
+    }
+
+    private static let sampleRateAddress = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyNominalSampleRate,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain)
+
+    private func installSampleRateListener(on deviceID: AudioObjectID) {
+        let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            guard let self,
+                  AudioDeviceManager.nominalSampleRate(deviceID) != self.processor.sampleRate else { return }
+            self.onSampleRateChange?()
+        }
+        var addr = Self.sampleRateAddress
+        if AudioObjectAddPropertyListenerBlock(deviceID, &addr, .main, block) == noErr {
+            sampleRateListener = block
+        }
+    }
+
+    private func removeSampleRateListener() {
+        guard let sampleRateListener, targetDeviceID != 0 else { return }
+        var addr = Self.sampleRateAddress
+        AudioObjectRemovePropertyListenerBlock(targetDeviceID, &addr, .main, sampleRateListener)
+        self.sampleRateListener = nil
     }
 
     private func readIOBufferSize() {


### PR DESCRIPTION
The engine reads the device's nominal sample rate once at start and bakes it into the biquad coefficients. If the rate changes while running — Bluetooth codec renegotiation, or switching it in Audio MIDI Setup — the coefficients stay on the old rate and every band shifts proportionally (48 → 44.1 kHz moves everything by ~9%), with no indication anything is wrong.

This adds a listener on `kAudioDevicePropertyNominalSampleRate` for the tapped device, installed on start and removed on stop. When the rate actually changes, the engine restarts through the existing rebuild path, so coefficients, spectrum bins, and latency all pick up the new rate. The rate check also prevents notification loops.

Tested by playing audio with an active EQ and flipping the output between 48 and 44.1 kHz in Audio MIDI Setup — bands stay on pitch after the switch. `swift run OnlyEQ --test` passes.
