### PR TITLE
Import GraphicEQ curves onto 31 third-octave bands

### DIFF
--- a/Sources/OnlyEQ/Models/PresetImporter.swift
+++ b/Sources/OnlyEQ/Models/PresetImporter.swift
@@ -156,8 +156,12 @@ enum PresetImporter {
         guard points.count >= 2 else { throw ImportError.empty }
         points.sort { $0.f < $1.f }
 
-        // Sample the graphic curve at 10 standard centers as Q 1.41 peaking bands.
-        let centers: [Double] = [31.5, 63, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
+        // Sample the graphic curve at the 31 ISO third-octave centers. The Q
+        // matching that spacing — sqrt(2^(1/3)) / (2^(1/3) − 1) ≈ 4.318 — keeps
+        // adjacent-band overlap from distorting the sampled gains.
+        let centers: [Double] = [20, 25, 31.5, 40, 50, 63, 80, 100, 125, 160, 200,
+                                 250, 315, 400, 500, 630, 800, 1000, 1250, 1600, 2000,
+                                 2500, 3150, 4000, 5000, 6300, 8000, 10000, 12500, 16000, 20000]
         func interpolate(_ f: Double) -> Double {
             if f <= points[0].f { return points[0].g }
             if f >= points[points.count - 1].f { return points[points.count - 1].g }
@@ -168,14 +172,14 @@ enum PresetImporter {
             }
             return 0
         }
-        let bands = centers.map { EQBand(type: .peak, frequency: $0, gain: (interpolate($0) * 10).rounded() / 10, q: 1.41) }
+        let bands = centers.map { EQBand(type: .peak, frequency: $0, gain: (interpolate($0) * 10).rounded() / 10, q: 4.318) }
         // Graphic exports usually bake preamp in (max gain ≤ 0); if not, compensate.
         let maxGain = bands.map(\.gain).max() ?? 0
         let preamp = maxGain > 0 ? -maxGain : 0
         return ImportResult(
             preset: EQPreset(name: "Imported", preampDB: preamp, bands: bands, source: "GraphicEQ"),
             detectedFormat: "GraphicEQ (Wavelet)",
-            warnings: ["Graphic curve was fitted onto 10 parametric bands."]
+            warnings: ["Graphic curve was fitted onto 31 parametric bands."]
         )
     }
 

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -45,12 +45,19 @@ enum TestRunner {
 
         r = try PresetImporter.importData(fixture("graphiceq.txt"))
         expect(r.detectedFormat == "GraphicEQ (Wavelet)", "graphiceq format")
-        expect(r.preset.bands.count == 10, "graphiceq 10 bands")
-        expect(r.preset.bands.allSatisfy { $0.type == .peak && $0.q == 1.41 }, "graphiceq peaking Q1.41")
+        expect(r.preset.bands.count == 31, "graphiceq 31 ISO third-octave bands")
+        expect(r.preset.bands.allSatisfy { $0.type == .peak && near($0.q, 4.318) }, "graphiceq third-octave Q")
         expect(r.preset.preampDB == 0, "graphiceq no preamp for negative gains")
         if let b125 = r.preset.bands.first(where: { $0.frequency == 125 }) {
-            expect(b125.gain < -2.0 && b125.gain > -3.0, "graphiceq interpolation")
+            expect(near(b125.gain, -2.3), "graphiceq interpolation at 125 Hz")
         } else { expect(false, "graphiceq 125 Hz band exists") }
+        if let b315 = r.preset.bands.first(where: { $0.frequency == 315 }) {
+            expect(near(b315.gain, -2.7), "graphiceq interpolation at 315 Hz")
+        } else { expect(false, "graphiceq 315 Hz band exists") }
+        expect(r.preset.bands.first?.frequency == 20 && near(r.preset.bands.first?.gain ?? 0, -0.2),
+               "graphiceq clamps below first point")
+        expect(r.preset.bands.last?.frequency == 20000 && near(r.preset.bands.last?.gain ?? 0, -6.4),
+               "graphiceq clamps above last point")
 
         r = try PresetImporter.importData(fixture("poweramp.json"))
         expect(r.detectedFormat == "Poweramp JSON", "poweramp format")


### PR DESCRIPTION
GraphicEQ imports (Wavelet / AutoEq graphic exports) were sampled onto 10 fixed centers with Q 1.41. That undersamples curves that typically carry ~127 points, and the wide Q makes adjacent bands overlap enough that even the sampled gains come out wrong after they sum.

Now the curve is sampled at the 31 ISO third-octave centers with Q 4.318 — the Q that matches third-octave spacing — so neighboring bands barely interact and the reconstruction tracks the source curve much more closely.

Updated the importer tests with exact interpolation values and edge clamping; `swift run OnlyEQ --test` passes.
