### PR TITLE
Remember the working preset per output device

### DIFF
--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -213,9 +213,17 @@ final class AppState: ObservableObject {
     }
 
     private func handleDefaultDeviceChanged() {
+        let previousUID = currentDevice?.uid
         refreshDevices()
         if isEnabled { rebuildEngine() }
-        applyDeviceProfileIfNeeded()
+        if previousUID != currentDevice?.uid {
+            // Stash the outgoing device's working EQ (including unsaved edits)
+            // so switching back restores it. Duplicate notifications for the
+            // same device must not re-apply anything — that would discard
+            // edits made since the profile was applied.
+            if let previousUID { store.stashWorkingPreset(preset, forDevice: previousUID) }
+            applyDeviceProfileIfNeeded()
+        }
         suggestProfileForCurrentDeviceIfNeeded()
     }
 
@@ -238,8 +246,12 @@ final class AppState: ObservableObject {
 
     private func applyDeviceProfileIfNeeded() {
         guard let device = currentDevice else { return }
-        if let profile = store.deviceProfiles[device.uid], profile.autoApply,
-           let saved = store.resolveProfilePreset(profile) {
+        if let stashed = store.workingPreset(forDevice: device.uid) {
+            // The user's last working state on this device — it already
+            // reflects the profile plus any manual edits made on top of it.
+            preset = stashed
+        } else if let profile = store.deviceProfiles[device.uid], profile.autoApply,
+                  let saved = store.resolveProfilePreset(profile) {
             preset = saved
         } else {
             // No usable assignment for the new device — reset to flat rather
@@ -276,6 +288,9 @@ final class AppState: ObservableObject {
         store.save(preset)
         store.setProfile(deviceUID: suggestion.deviceUID, deviceName: suggestion.deviceName,
                          preset: preset, autoApply: true)
+        // An explicit assignment beats whatever working state was stashed for
+        // the device — otherwise the stash would shadow it on next connect.
+        store.stashWorkingPreset(preset, forDevice: suggestion.deviceUID)
         if currentDevice?.uid == suggestion.deviceUID {
             self.preset = preset
             presetWasAutoApplied = true

--- a/Sources/OnlyEQ/Models/PresetStore.swift
+++ b/Sources/OnlyEQ/Models/PresetStore.swift
@@ -7,9 +7,15 @@ final class PresetStore: ObservableObject {
     @Published private(set) var customPresets: [EQPreset] = []
     @Published var deviceProfiles: [String: DeviceProfile] = [:]  // keyed by device UID
 
+    /// Working (possibly unsaved) EQ state per device UID, stashed on output
+    /// switches so returning to a device restores manual edits instead of
+    /// discarding them.
+    private var workingPresets: [String: EQPreset] = [:]
+
     private let directory: URL
     private var presetsURL: URL { directory.appendingPathComponent("presets.json") }
     private var profilesURL: URL { directory.appendingPathComponent("profiles.json") }
+    private var workingURL: URL { directory.appendingPathComponent("working-presets.json") }
 
     var allPresets: [EQPreset] { EQPreset.builtIns + customPresets }
 
@@ -56,6 +62,15 @@ final class PresetStore: ObservableObject {
         persist()
     }
 
+    func stashWorkingPreset(_ preset: EQPreset, forDevice uid: String) {
+        workingPresets[uid] = preset
+        persist()
+    }
+
+    func workingPreset(forDevice uid: String) -> EQPreset? {
+        workingPresets[uid]
+    }
+
     func setProfile(deviceUID: String, deviceName: String, preset: EQPreset?, autoApply: Bool = true) {
         deviceProfiles[deviceUID] = DeviceProfile(
             deviceUID: deviceUID, deviceName: deviceName,
@@ -75,6 +90,10 @@ final class PresetStore: ObservableObject {
            let profiles = try? JSONDecoder().decode([String: DeviceProfile].self, from: data) {
             deviceProfiles = profiles
         }
+        if let data = try? Data(contentsOf: workingURL),
+           let working = try? JSONDecoder().decode([String: EQPreset].self, from: data) {
+            workingPresets = working
+        }
     }
 
     private func persist() {
@@ -82,5 +101,6 @@ final class PresetStore: ObservableObject {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         try? encoder.encode(customPresets).write(to: presetsURL, options: .atomic)
         try? encoder.encode(deviceProfiles).write(to: profilesURL, options: .atomic)
+        try? encoder.encode(workingPresets).write(to: workingURL, options: .atomic)
     }
 }

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -25,6 +25,7 @@ enum TestRunner {
         do {
             try importerTests()
             dspTests()
+            storeTests()
         } catch {
             failures.append("Uncaught error: \(error)")
         }
@@ -112,6 +113,28 @@ enum TestRunner {
         let data = try JSONEncoder().encode(original)
         r = try PresetImporter.importData(data)
         expect(r.detectedFormat == "OnlyEQ preset" && r.preset == original, "native round trip")
+    }
+
+    private static func storeTests() {
+        // `--test` runs on the main thread (see main.swift), so touching the
+        // MainActor-isolated PresetStore directly is safe.
+        MainActor.assumeIsolated {
+            let dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("OnlyEQ-tests-\(UUID().uuidString)", isDirectory: true)
+            defer { try? FileManager.default.removeItem(at: dir) }
+
+            let edited = EQPreset(name: "Working", preampDB: -3, bands: [
+                EQBand(type: .peak, frequency: 3000, gain: -4, q: 2),
+            ])
+            let store = PresetStore(directory: dir)
+            expect(store.workingPreset(forDevice: "uid-a") == nil, "no working preset for unknown device")
+            store.stashWorkingPreset(edited, forDevice: "uid-a")
+            expect(store.workingPreset(forDevice: "uid-a") == edited, "working preset stash round trip")
+            expect(store.workingPreset(forDevice: "uid-b") == nil, "stash is keyed by device UID")
+
+            let reloaded = PresetStore(directory: dir)
+            expect(reloaded.workingPreset(forDevice: "uid-a") == edited, "working preset stash persists to disk")
+        }
     }
 
     private static func dspTests() {


### PR DESCRIPTION
Switching outputs resets the EQ to the new device's profile, or flat. That part is right — a headphone correction curve shouldn't follow you to speakers — but it also silently throws away unsaved edits: tweak the EQ, have your AirPods auto-connect, and the tweaks are gone with no way back.

This stashes the working preset per device UID on every switch and restores it when you come back. Lookup order on arrival is stash → profile → flat, since the stash is just the profile plus whatever you edited on top of it. Explicitly assigning a preset to a device overwrites its stash so the assignment isn't shadowed on next connect. Duplicate default-device notifications for the same device no longer re-apply anything, which was another way edits could get wiped.

Store round-trip and persistence are covered in the test suite (`swift run OnlyEQ --test` passes); the switching behavior was verified by hand with two outputs.