### PR TITLE
Skip DSP work while nothing is playing

### DIFF
--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -89,8 +89,16 @@ final class AppState: ObservableObject {
     @Published var popoverIsVisible = false { didSet { updateVisualizationState() } }
     @Published var editorIsVisible = false { didSet { updateVisualizationState() } }
 
+    /// autoPreamp scans a 512-point response curve; during a band drag this is
+    /// read ~120×/s with unchanged bands, so memoize on the band values.
+    private var autoPreampCache: (bands: [EQBand], value: Double)?
+
     var effectivePreampDB: Double {
-        autoPreampEnabled ? EQResponse.autoPreamp(bands: preset.bands) : preset.preampDB
+        guard autoPreampEnabled else { return preset.preampDB }
+        if let cache = autoPreampCache, cache.bands == preset.bands { return cache.value }
+        let value = EQResponse.autoPreamp(bands: preset.bands)
+        autoPreampCache = (preset.bands, value)
+        return value
     }
 
     var latencyMilliseconds: Int { Int((engine.estimatedLatency * 1000).rounded()) }

--- a/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
+++ b/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
@@ -42,6 +42,8 @@ final class ProcessTapEngine {
     }
     private var inputChannels: [InputChannel] = []
     private var activeChannels: [UnsafeMutablePointer<Float>] = []
+    /// Consecutive all-zero input frames, saturated at one second's worth.
+    private var silentFrames = 0
 
     var onStateChange: ((State) -> Void)?
 
@@ -126,6 +128,7 @@ final class ProcessTapEngine {
 
         // 3. IOProc: tapped audio arrives as input, processed audio leaves as output.
         hasReceivedAudio = false
+        silentFrames = 0
         status = AudioDeviceCreateIOProcIDWithBlock(&ioProcID, aggregateID, nil) { [weak self] _, inInputData, _, outOutputData, _ in
             self?.render(input: inInputData, output: outOutputData)
         }
@@ -212,7 +215,7 @@ final class ProcessTapEngine {
 
     // MARK: - Render path (audio thread)
 
-    private func render(input: UnsafePointer<AudioBufferList>, output: UnsafeMutablePointer<AudioBufferList>) {
+    func render(input: UnsafePointer<AudioBufferList>, output: UnsafeMutablePointer<AudioBufferList>) {
         let inputList = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: input))
         let outputList = UnsafeMutableAudioBufferListPointer(output)
         guard inputList.count > 0, outputList.count > 0 else { return }
@@ -233,12 +236,31 @@ final class ProcessTapEngine {
         }
         guard !inputChannels.isEmpty, frameCount != .max, frameCount > 0 else { return }
 
-        if !hasReceivedAudio {
-            outer: for channel in inputChannels {
-                for i in 0..<min(frameCount, 64) where channel.pointer[i * channel.stride] != 0 {
-                    hasReceivedAudio = true
-                    break outer
+        // One peak scan of the raw input detects audio anywhere in the buffer,
+        // and a full ring-out window of exact silence means the EQ and limiter
+        // tails have decayed too — the DSP chain can idle until audio returns.
+        var inputPeak: Float = 0
+        for buffer in inputList {
+            guard let data = buffer.mData else { continue }
+            let count = Int(buffer.mDataByteSize) / MemoryLayout<Float>.size
+            guard count > 0 else { continue }
+            var peak: Float = 0
+            vDSP_maxmgv(data.assumingMemoryBound(to: Float.self), 1, &peak, vDSP_Length(count))
+            inputPeak = max(inputPeak, peak)
+        }
+        if inputPeak != 0 {
+            hasReceivedAudio = true
+            silentFrames = 0
+        } else {
+            let ringOutFrames = Int(processor.sampleRate)
+            silentFrames = min(silentFrames + frameCount, ringOutFrames)
+            if silentFrames == ringOutFrames {
+                for buffer in outputList {
+                    guard let data = buffer.mData else { continue }
+                    vDSP_vclr(data.assumingMemoryBound(to: Float.self), 1,
+                              vDSP_Length(Int(buffer.mDataByteSize) / MemoryLayout<Float>.size))
                 }
+                return
             }
         }
 

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -1,3 +1,4 @@
+import CoreAudio
 import Foundation
 
 /// Minimal self-test harness (CLT has no XCTest). Run with `swift run OnlyEQ --test`.
@@ -25,6 +26,8 @@ enum TestRunner {
         do {
             try importerTests()
             dspTests()
+            engineRenderTests()
+            appStateTests()
         } catch {
             failures.append("Uncaught error: \(error)")
         }
@@ -190,5 +193,84 @@ enum TestRunner {
         expect(HeadphoneNameMatcher.score(query: "WH-1000XM5", candidate: "Sony WH-1000XM5")
                > HeadphoneNameMatcher.score(query: "WH-1000XM5", candidate: "Sony WH-1000XM4"),
                "headphone matcher prioritizes exact model number")
+    }
+
+    /// Wraps interleaved sample storage in single-buffer AudioBufferLists and
+    /// drives the engine's render callback directly, without Core Audio.
+    private static func renderOnce(_ engine: ProcessTapEngine, channels: Int,
+                                   input: inout [Float], output: inout [Float]) {
+        input.withUnsafeMutableBufferPointer { inBuf in
+            output.withUnsafeMutableBufferPointer { outBuf in
+                var inputList = AudioBufferList(
+                    mNumberBuffers: 1,
+                    mBuffers: AudioBuffer(mNumberChannels: UInt32(channels),
+                                          mDataByteSize: UInt32(inBuf.count * MemoryLayout<Float>.size),
+                                          mData: UnsafeMutableRawPointer(inBuf.baseAddress)))
+                var outputList = AudioBufferList(
+                    mNumberBuffers: 1,
+                    mBuffers: AudioBuffer(mNumberChannels: UInt32(channels),
+                                          mDataByteSize: UInt32(outBuf.count * MemoryLayout<Float>.size),
+                                          mData: UnsafeMutableRawPointer(outBuf.baseAddress)))
+                engine.render(input: &inputList, output: &outputList)
+            }
+        }
+    }
+
+    private static func engineRenderTests() {
+        let frames = 512, channels = 2
+
+        // Audio starting later in the buffer must still mark the tap as live.
+        let lateEngine = ProcessTapEngine()
+        var lateInput = [Float](repeating: 0, count: frames * channels)
+        for frame in 100..<frames { lateInput[frame * channels] = 0.5 }
+        var output = [Float](repeating: 0, count: frames * channels)
+        renderOnce(lateEngine, channels: channels, input: &lateInput, output: &output)
+        expect(lateEngine.hasReceivedAudio, "render detects audio past the first 64 frames")
+
+        // After a full ring-out window of exact silence the output stays zeroed
+        // and the tap is still not considered live.
+        let engine = ProcessTapEngine()
+        var silence = [Float](repeating: 0, count: frames * channels)
+        for _ in 0...(Int(engine.processor.sampleRate) / frames + 1) {
+            renderOnce(engine, channels: channels, input: &silence, output: &output)
+        }
+        var staleOutput = [Float](repeating: 0.7, count: frames * channels)
+        renderOnce(engine, channels: channels, input: &silence, output: &staleOutput)
+        expect(staleOutput.allSatisfy { $0 == 0 }, "silent input renders silent output after ring-out")
+        expect(!engine.hasReceivedAudio, "pure silence never marks the tap as live")
+
+        // The first non-silent buffer after prolonged silence passes through
+        // immediately (no dropout from the idle path).
+        var tone = (0..<frames * channels).map {
+            Float(0.5 * sin(Double($0 / channels) * 2 * .pi * 440 / 48000))
+        }
+        var resumed = [Float](repeating: 0, count: frames * channels)
+        renderOnce(engine, channels: channels, input: &tone, output: &resumed)
+        expect((resumed.map(abs).max() ?? 0) > 0.4, "audio resumes immediately after prolonged silence")
+        expect(engine.hasReceivedAudio, "resumed audio marks the tap as live")
+    }
+
+    private static func appStateTests() {
+        MainActor.assumeIsolated {
+            AppState.screenshotMode = true  // no engine, no persistence
+            let state = AppState.shared
+            let savedPreset = state.preset
+            let savedAuto = state.autoPreampEnabled
+            defer {
+                state.preset = savedPreset
+                state.autoPreampEnabled = savedAuto
+            }
+
+            state.autoPreampEnabled = true
+            state.preset = EQPreset(name: "Auto A", bands: [EQBand(type: .peak, frequency: 1000, gain: 5, q: 1.41)])
+            expect(near(state.effectivePreampDB, -5, 0.1), "effective preamp follows auto preamp")
+            expect(near(state.effectivePreampDB, state.effectivePreampDB), "repeated reads are stable")
+            state.preset = EQPreset(name: "Auto B", bands: [EQBand(type: .peak, frequency: 1000, gain: 8, q: 1.41)])
+            expect(near(state.effectivePreampDB, -8, 0.1), "effective preamp tracks band edits")
+
+            state.autoPreampEnabled = false
+            state.preset.preampDB = -3
+            expect(state.effectivePreampDB == -3, "manual preamp used when auto is off")
+        }
     }
 }


### PR DESCRIPTION
The tap keeps delivering buffers while playback is paused, so the engine was
running the full EQ chain on pure zeros all day. This adds a cheap vDSP peak
scan per callback; after a second of exact silence — enough for the filter and
limiter tails to die out — the render path just clears the output and returns
until audio comes back. The scan also replaces the old first-64-frames probe
for hasReceivedAudio, which could miss audio starting mid-buffer.

While at it, the auto-preamp value (a 512-point curve scan) is now memoized on
the band values. It was being recomputed ~120 times a second while dragging a
band node, once for the processor update and once for the editor's preamp label.

With playback paused, CPU settles around 0.3% here. New checks in the test
runner cover the silence gate — output stays zeroed while idle, and the first
non-silent buffer passes through immediately — plus the preamp cache.