### PR TITLE
Match editor interaction to the display refresh rate

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.2.2</string>
 	<key>CFBundleExecutable</key>

--- a/Sources/OnlyEQ/App/AppDelegate.swift
+++ b/Sources/OnlyEQ/App/AppDelegate.swift
@@ -247,11 +247,13 @@ final class WindowManager {
             window.title = "OnlyEQ"
             window.minSize = NSSize(width: 720, height: 480)
             window.isReleasedWhenClosed = false
-            window.contentViewController = NSHostingController(
+            let hosting = NSHostingController(
                 rootView: EditorView(initialImportRequested: importing,
                                      initialProfileSuggestion: profileSuggestion)
                     .environmentObject(AppState.shared)
             )
+            hosting.sizingOptions = .standardBounds
+            window.contentViewController = hosting
             // Restore the saved frame if there is one; otherwise center.
             if !window.setFrameUsingName("EditorWindow") { window.center() }
             window.setFrameAutosaveName("EditorWindow")

--- a/Sources/OnlyEQ/UI/DisplayRefreshRate.swift
+++ b/Sources/OnlyEQ/UI/DisplayRefreshRate.swift
@@ -1,0 +1,29 @@
+import AppKit
+import QuartzCore
+
+/// Keeps interactive UI work synchronized with the display that owns the
+/// active window. A 120 Hz ProMotion screen gets 120 Hz presentation while a
+/// conventional screen remains at 60 Hz.
+@MainActor
+enum DisplayRefreshRate {
+    static func maximum(for window: NSWindow? = nil) -> Double {
+        let screen = window?.screen ?? NSApp.keyWindow?.screen ?? NSScreen.main
+        return Double(max(screen?.maximumFramesPerSecond ?? 60, 1))
+    }
+
+    static func interval(for window: NSWindow? = nil) -> TimeInterval {
+        1.0 / maximum(for: window)
+    }
+
+    static func configure(_ link: CADisplayLink, for window: NSWindow?) {
+        // Allow the fastest connected display. The NSView-owned display link
+        // is still physically paced by its current screen, so a 60 Hz screen
+        // receives 60 callbacks while moving to ProMotion can reach 120 Hz
+        // without recreating the link.
+        let connectedMaximum = NSScreen.screens.map(\.maximumFramesPerSecond).max()
+        let maximum = Float(max(connectedMaximum ?? Int(maximum(for: window)), 1))
+        link.preferredFrameRateRange = CAFrameRateRange(
+            minimum: min(60, maximum), maximum: maximum, preferred: maximum
+        )
+    }
+}

--- a/Sources/OnlyEQ/UI/EQCurveView.swift
+++ b/Sources/OnlyEQ/UI/EQCurveView.swift
@@ -7,6 +7,63 @@ enum BandPalette {
     static func color(_ index: Int) -> Color { colors[index % colors.count] }
 }
 
+/// Frequency responses depend on filter parameters, not view dimensions. Keep
+/// them stable across live-resize frames and recompute only bands that changed.
+@MainActor
+private final class EQCurveResponseCache: ObservableObject {
+    struct Data {
+        var combinedFrequencies: [Double]
+        var combinedResponse: [Double]
+        var individualFrequencies: [Double]
+        var individualResponses: [(index: Int, response: [Double])]
+    }
+
+    private static let combinedFrequencies = EQResponse.logGrid(count: 128)
+    private static let individualFrequencies = EQResponse.logGrid(count: 96)
+    private var cachedBands: [EQBand] = []
+    private var cachedPreampDB = Double.nan
+    private var cachedCombined: [Double] = []
+    private var individualBands: [EQBand] = []
+    private var individualResponses: [[Double]] = []
+
+    func data(bands: [EQBand], preampDB: Double, includeIndividuals: Bool) -> Data {
+        if bands != cachedBands || preampDB != cachedPreampDB {
+            cachedBands = bands
+            cachedPreampDB = preampDB
+            cachedCombined = EQResponse.curve(
+                bands: bands, preampDB: preampDB, frequencies: Self.combinedFrequencies
+            )
+        }
+
+        var enabledResponses: [(index: Int, response: [Double])] = []
+        if includeIndividuals {
+            if individualBands.count != bands.count {
+                individualBands = bands
+                individualResponses = bands.map {
+                    EQResponse.curve(bands: [$0], preampDB: 0, frequencies: Self.individualFrequencies)
+                }
+            } else {
+                for index in bands.indices where bands[index] != individualBands[index] {
+                    individualBands[index] = bands[index]
+                    individualResponses[index] = EQResponse.curve(
+                        bands: [bands[index]], preampDB: 0, frequencies: Self.individualFrequencies
+                    )
+                }
+            }
+            enabledResponses = bands.indices.compactMap { index in
+                bands[index].isEnabled ? (index, individualResponses[index]) : nil
+            }
+        }
+
+        return Data(
+            combinedFrequencies: Self.combinedFrequencies,
+            combinedResponse: cachedCombined,
+            individualFrequencies: Self.individualFrequencies,
+            individualResponses: enabledResponses
+        )
+    }
+}
+
 /// The hero EQ curve: log-frequency response with optional live spectrum bars
 /// behind it and optional draggable band nodes (editor mode).
 struct EQCurveView: View {
@@ -28,6 +85,7 @@ struct EQCurveView: View {
     var onBandChange: ((UUID, _ frequency: Double, _ gain: Double) -> Void)?
     var onBandDragEnded: (() -> Void)?
     var onAddBand: ((_ frequency: Double, _ gain: Double) -> Void)?
+    @StateObject private var responseCache = EQCurveResponseCache()
 
     private let minF = 20.0, maxF = 20000.0
 
@@ -52,12 +110,15 @@ struct EQCurveView: View {
     }
 
     var body: some View {
+        let responseData = responseCache.data(
+            bands: bands, preampDB: preampDB, includeIndividuals: showIndividualCurves
+        )
         GeometryReader { geo in
             let size = geo.size
             ZStack {
                 gridLayer(size: size)
                 if showSpectrum { SpectrumBarsView(style: spectrumStyle) }
-                curveLayer(size: size)
+                curveLayer(size: size, data: responseData)
                 if interactive { nodeLayer(size: size) }
             }
             .contentShape(Rectangle())
@@ -104,30 +165,31 @@ struct EQCurveView: View {
         }
     }
 
-    private func curvePoints(size: CGSize) -> [CGPoint] {
-        let freqs = EQResponse.logGrid(count: 128)
-        let response = EQResponse.curve(bands: bands, preampDB: preampDB, frequencies: freqs)
-        return zip(freqs, response).map { CGPoint(x: x(forFrequency: $0, size), y: y(forDB: min(max($1, -rangeDB), rangeDB), size)) }
+    private func curvePoints(size: CGSize, data: EQCurveResponseCache.Data) -> [CGPoint] {
+        zip(data.combinedFrequencies, data.combinedResponse).map {
+            CGPoint(x: x(forFrequency: $0, size),
+                    y: y(forDB: min(max($1, -rangeDB), rangeDB), size))
+        }
     }
 
     @ViewBuilder
-    private func curveLayer(size: CGSize) -> some View {
+    private func curveLayer(size: CGSize, data: EQCurveResponseCache.Data) -> some View {
         Canvas { ctx, _ in
             // Individual band curves (editor only).
             if showIndividualCurves {
-                let freqs = EQResponse.logGrid(count: 96)
-                for (i, band) in bands.enumerated() where band.isEnabled {
-                    let response = EQResponse.curve(bands: [band], preampDB: 0, frequencies: freqs)
+                for item in data.individualResponses {
                     var path = Path()
-                    for (j, f) in freqs.enumerated() {
-                        let p = CGPoint(x: x(forFrequency: f, size), y: y(forDB: min(max(response[j], -rangeDB), rangeDB), size))
+                    for (j, f) in data.individualFrequencies.enumerated() {
+                        let p = CGPoint(x: x(forFrequency: f, size),
+                                        y: y(forDB: min(max(item.response[j], -rangeDB), rangeDB), size))
                         if j == 0 { path.move(to: p) } else { path.addLine(to: p) }
                     }
-                    ctx.stroke(path, with: .color(BandPalette.color(i).opacity(0.22)), style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                    ctx.stroke(path, with: .color(BandPalette.color(item.index).opacity(0.22)),
+                               style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
                 }
             }
 
-            let points = curvePoints(size: size)
+            let points = curvePoints(size: size, data: data)
             guard points.count > 1 else { return }
 
             var fill = Path()
@@ -252,7 +314,7 @@ private final class SpectrumBarsNSView: NSView {
         lastAnalysisTime = 0
 
         let link = displayLink(target: self, selector: #selector(displayLinkDidFire(_:)))
-        link.preferredFrameRateRange = CAFrameRateRange(minimum: 60, maximum: 60, preferred: 60)
+        DisplayRefreshRate.configure(link, for: window)
         link.add(to: .main, forMode: .common)
         animationLink = link
         renderBars(displayedBars)
@@ -267,7 +329,7 @@ private final class SpectrumBarsNSView: NSView {
 
     @objc private func displayLinkDidFire(_ link: CADisplayLink) {
         // FFT/magnitude work stays capped at 30 Hz. The layer interpolates the
-        // latest targets at 60 fps, so motion is smooth without doubling DSP.
+        // latest targets at the screen refresh rate without multiplying DSP.
         if lastAnalysisTime == 0 || link.timestamp - lastAnalysisTime >= 1.0 / 30.0 {
             let bars = spectrum.bars()
             if bars.count == targetBars.count {
@@ -330,6 +392,7 @@ private struct DraggableBandNode: View {
 
     @State private var dragPosition: CGPoint?
     @State private var lastModelUpdate: CFTimeInterval = 0
+    @State private var modelUpdateInterval: TimeInterval = 1.0 / 60.0
 
     private let minF = 20.0, maxF = 20000.0
 
@@ -350,7 +413,10 @@ private struct DraggableBandNode: View {
                     dragPosition = update.position
 
                     let now = CACurrentMediaTime()
-                    if lastModelUpdate == 0 || now - lastModelUpdate >= 1.0 / 60.0 {
+                    if lastModelUpdate == 0 {
+                        modelUpdateInterval = DisplayRefreshRate.interval()
+                    }
+                    if lastModelUpdate == 0 || now - lastModelUpdate >= modelUpdateInterval {
                         onChange?(band.id, update.frequency, update.gain)
                         lastModelUpdate = now
                     }

--- a/Sources/OnlyEQ/UI/EditorView.swift
+++ b/Sources/OnlyEQ/UI/EditorView.swift
@@ -358,7 +358,7 @@ private final class PeakMeterNSView: NSView {
     private func startAnimating() {
         guard animationLink == nil else { return }
         let link = displayLink(target: self, selector: #selector(samplePeak(_:)))
-        link.preferredFrameRateRange = CAFrameRateRange(minimum: 60, maximum: 60, preferred: 60)
+        DisplayRefreshRate.configure(link, for: window)
         link.add(to: .main, forMode: .common)
         animationLink = link
         samplePeak(link)

--- a/Sources/OnlyEQ/UI/PopoverView.swift
+++ b/Sources/OnlyEQ/UI/PopoverView.swift
@@ -274,6 +274,7 @@ struct BoostSlider: View {
     var maxPercent: Double
     @State private var trackedValue: Double?
     @State private var lastPublishedTime: TimeInterval = 0
+    @State private var publicationInterval: TimeInterval = 1.0 / 60.0
 
     var body: some View {
         let displayedValue = trackedValue ?? value
@@ -316,7 +317,10 @@ struct BoostSlider: View {
                             let updated = sliderValue(at: gesture.location.x, width: width)
                             trackedValue = updated
                             let now = ProcessInfo.processInfo.systemUptime
-                            if lastPublishedTime == 0 || now - lastPublishedTime >= 1.0 / 60.0 {
+                            if lastPublishedTime == 0 {
+                                publicationInterval = DisplayRefreshRate.interval()
+                            }
+                            if lastPublishedTime == 0 || now - lastPublishedTime >= publicationInterval {
                                 value = updated
                                 lastPublishedTime = now
                             }

--- a/appcast.xml
+++ b/appcast.xml
@@ -4,9 +4,9 @@
         <title>OnlyEQ</title>
         <item>
             <title>1.2.2</title>
-            <pubDate>Thu, 09 Jul 2026 18:57:40 -0700</pubDate>
+            <pubDate>Thu, 09 Jul 2026 21:56:20 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>11</sparkle:version>
+            <sparkle:version>12</sparkle:version>
             <sparkle:shortVersionString>1.2.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
             <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.2
@@ -15,8 +15,11 @@
 - Replaces the pointed popover shell with a rounded, arrowless menu panel.
 - Makes the OnlyEQ panel appear immediately and accept input as soon as the menu-bar icon is clicked.
 - Keeps the menu-bar icon brightly highlighted while the panel is open.
+- Matches EQ-node dragging, spectrum presentation, peak metering, and volume publication to the active display refresh rate, including 120 Hz ProMotion screens.
+- Caches size-independent EQ response data during live window resizing and recalculates only bands whose parameters changed.
+- Prevents editor intrinsic-size feedback while resizing its window.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.2/OnlyEQ.app.zip" length="2425878" type="application/octet-stream" sparkle:edSignature="hjvWngeWdI4XZ1it3UE0UITWjsUQpvtiwJhY/NfiYx5E/FIBQBQRMg40bTLLPxxvUq4pgrFmZDbGnvIsigGAAQ=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.2/OnlyEQ.app.zip" length="2434817" type="application/octet-stream" sparkle:edSignature="AheUiwyr9v2tX9jx7HszUHSKp2KGBBQKBt79h86Qf00ZZS+OlY4lYlfh1tTsXgjuJklB69+2xs0vG7e8oftiCw=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.2.2.md
+++ b/release-notes/1.2.2.md
@@ -4,3 +4,6 @@
 - Replaces the pointed popover shell with a rounded, arrowless menu panel.
 - Makes the OnlyEQ panel appear immediately and accept input as soon as the menu-bar icon is clicked.
 - Keeps the menu-bar icon brightly highlighted while the panel is open.
+- Matches EQ-node dragging, spectrum presentation, peak metering, and volume publication to the active display refresh rate, including 120 Hz ProMotion screens.
+- Caches size-independent EQ response data during live window resizing and recalculates only bands whose parameters changed.
+- Prevents editor intrinsic-size feedback while resizing its window.


### PR DESCRIPTION
## Summary

OnlyEQ interactions and lightweight presentation now follow the active display rather than a fixed 60 Hz cap. EQ nodes, the curve following them, spectrum interpolation, peak metering, and volume publication can run at 120 Hz on ProMotion while remaining 60 Hz on conventional displays. Window resizing also avoids recalculating unchanged filter responses.

## Why

The draggable nodes tracked pointer events locally, but their model/curve updates and several display links were still fixed at 60 Hz. Live resizing also recomputed every combined and per-band frequency response even when only the window dimensions changed.

## What

- Derive interaction intervals from the active window screen refresh rate.
- Allow NSView display links to use the fastest connected display while remaining physically paced by their current screen.
- Run node/model updates, spectrum presentation, peak metering, and volume publication at 60/120 Hz as appropriate.
- Keep FFT analysis independently capped at 30 Hz.
- Cache size-independent combined and individual EQ responses across resize frames.
- Recompute only the individual band whose filter parameters changed.
- Disable intrinsic-size feedback from the editor hosting controller.
- Update the existing 1.2.2 release to build 12.

## Solution

```mermaid
flowchart LR
    Screen[Active display 60 or 120 Hz] --> Schedule[Refresh-rate scheduler]
    Schedule --> Drag[Node and curve updates]
    Schedule --> Spectrum[Spectrum interpolation]
    Schedule --> Meter[Peak meter]
    Schedule --> Volume[Volume publication]
    Audio[Audio samples] -->|max 30 Hz FFT| Spectrum
    Resize[Window resize] --> Coordinates[Remap cached response coordinates]
    Filters[Filter parameter change] --> Cache[Recompute combined plus changed band]
    Cache --> Coordinates
```

Review order:

1. `Sources/OnlyEQ/UI/DisplayRefreshRate.swift` — shared screen-rate policy.
2. `Sources/OnlyEQ/UI/EQCurveView.swift` — native-rate dragging/presentation and response cache.
3. `Sources/OnlyEQ/UI/EditorView.swift` and `PopoverView.swift` — meter and volume scheduling.
4. `Sources/OnlyEQ/App/AppDelegate.swift` — resize hosting behavior.
5. Release metadata.

## Types of Changes

- [x] Performance improvement
- [x] User-visible enhancement
- [x] Release metadata
- [ ] Breaking change

## Test Plan

- `swift build -c release -Xswiftc -warnings-as-errors`
- `swift run -c release OnlyEQ --test` — 63 checks passed, 0 failed.
- Confirmed the current Mac display reports 120 Hz and the UI selects that rate.
- `swift run -c release OnlyEQ --editor-probe` — full editor typically 2.1–2.5% idle CPU at 120 Hz; sampling showed no recurring SwiftUI ViewGraph/layout path from visualization ticks.
- Performed a real live corner resize through macOS UI control; editor remained responsive and intact.
- `codesign --verify --deep --strict --verbose=2 build/OnlyEQ.app`
- `lipo -archs build/OnlyEQ.app/Contents/MacOS/OnlyEQ` — x86_64 arm64.
- `unzip -t build/OnlyEQ.app.zip` — no errors.

## Related Issues

No issue was provided; this implements native-refresh dragging and smoother resizing while retaining version 1.2.2.