### PR TITLE
Fix the arrowless menu panel click race

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.2.2</string>
 	<key>CFBundleExecutable</key>

--- a/Sources/OnlyEQ/App/AppDelegate.swift
+++ b/Sources/OnlyEQ/App/AppDelegate.swift
@@ -7,6 +7,9 @@ import Sparkle
 final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var statusItem: NSStatusItem!
     private var menuPanel: MenuPanel!
+    private var localMouseMonitor: Any?
+    private var appResignObserver: NSObjectProtocol?
+    private var hidePanelObserver: NSObjectProtocol?
     private let updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
         updaterDelegate: nil,
@@ -34,7 +37,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             styleMask: [.borderless], backing: .buffered, defer: false
         )
         menuPanel.contentViewController = hosting
-        menuPanel.delegate = self
         menuPanel.level = .popUpMenu
         menuPanel.isFloatingPanel = true
         menuPanel.hidesOnDeactivate = true
@@ -57,6 +59,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         }
         Log.write("app: status item ready (visible: \(statusItem.isVisible))")
+        installPanelDismissalObservers()
 
         if CommandLine.arguments.contains("--menu-panel-probe") {
             DispatchQueue.main.async { [weak self] in self?.togglePopover() }
@@ -72,6 +75,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        if let localMouseMonitor { NSEvent.removeMonitor(localMouseMonitor) }
+        if let appResignObserver { NotificationCenter.default.removeObserver(appResignObserver) }
+        if let hidePanelObserver { NotificationCenter.default.removeObserver(hidePanelObserver) }
         AppState.shared.flushWorkingPresetPersistence()
         AppState.shared.engine.stop()
     }
@@ -103,6 +109,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                 button?.highlight(true)
             }
             AppState.shared.popoverIsVisible = true
+            Log.write("menu-panel: shown")
+        }
+    }
+
+    private func installPanelDismissalObservers() {
+        localMouseMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] event in
+            guard let self, self.menuPanel.isVisible else { return event }
+            let statusWindow = self.statusItem.button?.window
+            if event.window !== self.menuPanel, event.window !== statusWindow {
+                DispatchQueue.main.async { [weak self] in self?.hideMenuPanel() }
+            }
+            return event
+        }
+
+        appResignObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: NSApp, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.hideMenuPanel() }
+        }
+
+        hidePanelObserver = NotificationCenter.default.addObserver(
+            forName: .onlyEQHideMenuPanel,
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.hideMenuPanel() }
         }
     }
 
@@ -119,9 +153,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     private func hideMenuPanel() {
+        let wasVisible = menuPanel.isVisible
         statusItem.button?.highlight(false)
-        if menuPanel.isVisible { menuPanel.orderOut(nil) }
+        if wasVisible { menuPanel.orderOut(nil) }
         AppState.shared.popoverIsVisible = false
+        if wasVisible { Log.write("menu-panel: hidden") }
     }
 
     private func showContextMenu() {
@@ -210,14 +246,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     @objc private func checkForUpdates() { updaterController.checkForUpdates(nil) }
 }
 
-extension AppDelegate: NSWindowDelegate {
-    func windowDidResignKey(_ notification: Notification) {
-        guard notification.object as? NSWindow === menuPanel else { return }
-        DispatchQueue.main.async { [weak self] in
-            guard let self, !self.menuPanel.isKeyWindow else { return }
-            self.hideMenuPanel()
-        }
-    }
+private extension Notification.Name {
+    static let onlyEQHideMenuPanel = Notification.Name("OnlyEQ.HideMenuPanel")
 }
 
 /// Borderless AppKit windows do not normally become key. This tiny subclass
@@ -321,6 +351,7 @@ final class WindowManager {
     /// key. Retry on the next run-loop turn because a closing transient popover
     /// can otherwise return focus to the previous application.
     private func focus(_ window: NSWindow) {
+        NotificationCenter.default.post(name: .onlyEQHideMenuPanel, object: nil)
         NSApp.activate(ignoringOtherApps: true)
         window.makeKeyAndOrderFront(nil)
         DispatchQueue.main.async { [weak window] in

--- a/Sources/OnlyEQ/UI/EditorView.swift
+++ b/Sources/OnlyEQ/UI/EditorView.swift
@@ -203,26 +203,40 @@ struct EditorView: View {
 
     private var bottomBar: some View {
         HStack(spacing: 12) {
-            Text("Preamp").font(.system(size: 11)).foregroundStyle(.secondary)
+            Text("Preamp")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: true, vertical: false)
+                .layoutPriority(2)
             Text(String(format: "%.1f dB", state.effectivePreampDB))
                 .font(.system(size: 11, weight: .medium).monospacedDigit())
                 .frame(width: 52, alignment: .trailing)
+                .fixedSize(horizontal: true, vertical: false)
+                .layoutPriority(2)
             Slider(value: Binding(
                 get: { state.preset.preampDB },
                 set: { state.preset.preampDB = ($0 * 10).rounded() / 10 }
             ), in: -20...0)
-                .frame(width: 160)
+                .frame(minWidth: 72, idealWidth: 150, maxWidth: 160)
                 .disabled(state.autoPreampEnabled)
             Toggle("Auto", isOn: $state.autoPreampEnabled)
                 .toggleStyle(.checkbox)
+                .fixedSize(horizontal: true, vertical: false)
+                .layoutPriority(2)
             clipIndicator
+                .fixedSize(horizontal: true, vertical: false)
+                .layoutPriority(1)
             Spacer()
             Toggle("Limiter", isOn: $state.limiterEnabled)
                 .toggleStyle(AccentSwitchStyle(width: 30))
+                .fixedSize(horizontal: true, vertical: false)
+                .layoutPriority(2)
             Button("Reset") {
                 state.applyFlat()
                 selectedBandID = nil
             }
+            .fixedSize(horizontal: true, vertical: false)
+            .layoutPriority(2)
         }
         .controlSize(.small)
         .padding(.horizontal, 24)

--- a/appcast.xml
+++ b/appcast.xml
@@ -4,9 +4,9 @@
         <title>OnlyEQ</title>
         <item>
             <title>1.2.2</title>
-            <pubDate>Thu, 09 Jul 2026 21:56:20 -0700</pubDate>
+            <pubDate>Thu, 09 Jul 2026 22:10:37 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>12</sparkle:version>
+            <sparkle:version>13</sparkle:version>
             <sparkle:shortVersionString>1.2.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
             <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.2
@@ -18,8 +18,11 @@
 - Matches EQ-node dragging, spectrum presentation, peak metering, and volume publication to the active display refresh rate, including 120 Hz ProMotion screens.
 - Caches size-independent EQ response data during live window resizing and recalculates only bands whose parameters changed.
 - Prevents editor intrinsic-size feedback while resizing its window.
+- Fixes the real status-icon click path so the arrowless panel no longer closes immediately when mouse tracking releases key focus.
+- Uses explicit outside-click, app-deactivation, and window-opening dismissal instead of fragile key-window loss.
+- Keeps bottom-bar labels, toggles, and buttons intact at narrow editor widths while allowing the preamp slider to shrink fluidly.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.2/OnlyEQ.app.zip" length="2434817" type="application/octet-stream" sparkle:edSignature="AheUiwyr9v2tX9jx7HszUHSKp2KGBBQKBt79h86Qf00ZZS+OlY4lYlfh1tTsXgjuJklB69+2xs0vG7e8oftiCw=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.2/OnlyEQ.app.zip" length="2444565" type="application/octet-stream" sparkle:edSignature="Ep3tGwYP1iuiOlDMLTW1qa9fcBZILcaPzEAX9UipyNi3QsUCkvg9MA7ZHrxTz/u/aoUHRB+zgSXkdniZpkj4Ag=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.2.2.md
+++ b/release-notes/1.2.2.md
@@ -7,3 +7,6 @@
 - Matches EQ-node dragging, spectrum presentation, peak metering, and volume publication to the active display refresh rate, including 120 Hz ProMotion screens.
 - Caches size-independent EQ response data during live window resizing and recalculates only bands whose parameters changed.
 - Prevents editor intrinsic-size feedback while resizing its window.
+- Fixes the real status-icon click path so the arrowless panel no longer closes immediately when mouse tracking releases key focus.
+- Uses explicit outside-click, app-deactivation, and window-opening dismissal instead of fragile key-window loss.
+- Keeps bottom-bar labels, toggles, and buttons intact at narrow editor widths while allowing the preamp slider to shrink fluidly.


### PR DESCRIPTION
## Summary

The arrowless menu panel now opens reliably from the real menu-bar click path. The editor bottom bar also remains readable and usable at minimum and tall/narrow window sizes.

## Why

The programmatic panel probe passed, but a real status-button mouse-up briefly transferred key focus away from the new borderless panel. A `windowDidResignKey` dismissal handler then hid it immediately. The resized editor also allowed bottom-bar labels to collapse into vertical one-letter columns.

## What

- Remove key-window-loss as a panel dismissal trigger.
- Dismiss explicitly on outside app clicks, application deactivation, and opening another OnlyEQ window.
- Preserve second-click toggling, right-click menus, device/preset menus, status highlight, and visualization visibility gating.
- Add panel lifecycle logging for regressions.
- Make bottom-bar semantic controls fixed-width/high-priority and let the preamp slider yield width.
- Update the existing 1.2.2 release to build 13.

## Solution

```mermaid
flowchart LR
    Status[Status mouse-up] --> Show[Show arrowless panel]
    Show --> Remain[Remain visible despite transient key loss]
    Outside[Outside click] --> Hide[Explicit hide]
    Deactivate[App deactivation] --> Hide
    OtherWindow[Open Editor or Settings] --> Hide
    Status -->|second click| Hide
    Resize[Editor width changes] --> Slider[Flexible preamp slider]
    Resize --> Fixed[Fixed labels toggles and buttons]
```

Review order:

1. `Sources/OnlyEQ/App/AppDelegate.swift` — corrected panel lifecycle and focus handling.
2. `Sources/OnlyEQ/UI/EditorView.swift` — responsive bottom-bar priorities.
3. Release metadata and notes.

## Types of Changes

- [x] Bug fix
- [x] Responsive-layout fix
- [x] Release metadata
- [ ] Breaking change

## Test Plan

- Real normal-launch status-item click: panel remained visible and logged `menu-panel: shown`.
- 20 rapid status clicks: 20 alternating lifecycle transitions; process remained alive.
- Three cold relaunch/click cycles: all logged successful presentation.
- Finder/app deactivation: panel dismissed and highlight cleared.
- Device menu activation: panel remained present while the menu was active.
- Editor button: panel dismissed; Editor became focused/key.
- Settings button: panel dismissed; Settings became focused/key.
- Existing Editor + Settings: panel added/removed without disturbing either window.
- 720×480 minimum layout: all bottom controls remained on one line.
- 35 resize cycles: process remained alive at ~2.1% CPU; sample contained zero `EQResponse.curve` or `BiquadCoefficients.make` frames.
- `swift build -c release -Xswiftc -warnings-as-errors`
- `swift run -c release OnlyEQ --test` — 63 checks passed, 0 failed.
- `codesign --verify --deep --strict --verbose=2 build/OnlyEQ.app`
- Universal x86_64/arm64 binary and clean archive integrity test.

## Related Issues

No issue was provided; this fixes the reported inability to open build 12 and the narrow-layout screenshot while retaining version 1.2.2.