### PR TITLE
Restore native editor resizing in 1.2.2

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.2.2</string>
 	<key>CFBundleExecutable</key>

--- a/Sources/OnlyEQ/App/AppDelegate.swift
+++ b/Sources/OnlyEQ/App/AppDelegate.swift
@@ -8,7 +8,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var statusItem: NSStatusItem!
     private var menuPanel: MenuPanel!
     private var localMouseMonitor: Any?
-    private var appResignObserver: NSObjectProtocol?
+    private var globalMouseMonitor: Any?
+    private var workspaceActivationObserver: NSObjectProtocol?
     private var hidePanelObserver: NSObjectProtocol?
     private let updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
@@ -39,7 +40,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         menuPanel.contentViewController = hosting
         menuPanel.level = .popUpMenu
         menuPanel.isFloatingPanel = true
-        menuPanel.hidesOnDeactivate = true
+        menuPanel.hidesOnDeactivate = false
         menuPanel.isReleasedWhenClosed = false
         menuPanel.hasShadow = true
         menuPanel.isOpaque = false
@@ -76,7 +77,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         if let localMouseMonitor { NSEvent.removeMonitor(localMouseMonitor) }
-        if let appResignObserver { NotificationCenter.default.removeObserver(appResignObserver) }
+        if let globalMouseMonitor { NSEvent.removeMonitor(globalMouseMonitor) }
+        if let workspaceActivationObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(workspaceActivationObserver)
+        }
         if let hidePanelObserver { NotificationCenter.default.removeObserver(hidePanelObserver) }
         AppState.shared.flushWorkingPresetPersistence()
         AppState.shared.engine.stop()
@@ -125,10 +129,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             return event
         }
 
-        appResignObserver = NotificationCenter.default.addObserver(
-            forName: NSApplication.didResignActiveNotification,
-            object: NSApp, queue: .main
+        globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
         ) { [weak self] _ in
+            Task { @MainActor in self?.hideMenuPanel() }
+        }
+
+        workspaceActivationObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil, queue: .main
+        ) { [weak self] notification in
+            let application = notification.userInfo?[NSWorkspace.applicationUserInfoKey]
+                as? NSRunningApplication
+            guard application?.processIdentifier != ProcessInfo.processInfo.processIdentifier else { return }
             Task { @MainActor in self?.hideMenuPanel() }
         }
 
@@ -282,7 +295,6 @@ final class WindowManager {
                                      initialProfileSuggestion: profileSuggestion)
                     .environmentObject(AppState.shared)
             )
-            hosting.sizingOptions = .standardBounds
             window.contentViewController = hosting
             // Restore the saved frame if there is one; otherwise center.
             if !window.setFrameUsingName("EditorWindow") { window.center() }

--- a/Sources/OnlyEQ/main.swift
+++ b/Sources/OnlyEQ/main.swift
@@ -33,25 +33,14 @@ if editorProbe || profileSuggestionProbe {
         let state = AppState.shared
         state.engineState = .running
         state.editorIsVisible = true
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 840, height: 560),
-            styleMask: [.titled, .closable, .resizable],
-            backing: .buffered,
-            defer: false
+        WindowManager.shared.showEditor(
+            importing: profileSuggestionProbe,
+            profileSuggestion: profileSuggestionProbe ? ProfileSuggestion(
+                deviceUID: "probe.bluetooth.headphones",
+                deviceName: "Aaron’s WH-1000XM5 Stereo",
+                searchQuery: "WH-1000XM5"
+            ) : nil
         )
-        window.title = "OnlyEQ UI Probe"
-        window.contentViewController = NSHostingController(
-            rootView: EditorView(
-                initialImportRequested: profileSuggestionProbe,
-                initialProfileSuggestion: profileSuggestionProbe ? ProfileSuggestion(
-                    deviceUID: "probe.bluetooth.headphones",
-                    deviceName: "Aaron’s WH-1000XM5 Stereo",
-                    searchQuery: "WH-1000XM5"
-                ) : nil
-            ).environmentObject(state)
-        )
-        window.center()
-        window.makeKeyAndOrderFront(nil)
         app.activate(ignoringOtherApps: true)
         DispatchQueue.main.asyncAfter(deadline: .now() + 15) { app.terminate(nil) }
         app.run()

--- a/appcast.xml
+++ b/appcast.xml
@@ -4,9 +4,9 @@
         <title>OnlyEQ</title>
         <item>
             <title>1.2.2</title>
-            <pubDate>Thu, 09 Jul 2026 22:10:37 -0700</pubDate>
+            <pubDate>Thu, 09 Jul 2026 22:19:11 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>13</sparkle:version>
+            <sparkle:version>14</sparkle:version>
             <sparkle:shortVersionString>1.2.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
             <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.2
@@ -17,12 +17,13 @@
 - Keeps the menu-bar icon brightly highlighted while the panel is open.
 - Matches EQ-node dragging, spectrum presentation, peak metering, and volume publication to the active display refresh rate, including 120 Hz ProMotion screens.
 - Caches size-independent EQ response data during live window resizing and recalculates only bands whose parameters changed.
-- Prevents editor intrinsic-size feedback while resizing its window.
+- Keeps editor hosting unconstrained so AppKit edge and corner resizing remains available.
 - Fixes the real status-icon click path so the arrowless panel no longer closes immediately when mouse tracking releases key focus.
 - Uses explicit outside-click, app-deactivation, and window-opening dismissal instead of fragile key-window loss.
+- Avoids `hidesOnDeactivate`, which could invisibly order out an accessory-app panel immediately after a real status click; global clicks and workspace activation now own dismissal.
 - Keeps bottom-bar labels, toggles, and buttons intact at narrow editor widths while allowing the preamp slider to shrink fluidly.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.2/OnlyEQ.app.zip" length="2444565" type="application/octet-stream" sparkle:edSignature="Ep3tGwYP1iuiOlDMLTW1qa9fcBZILcaPzEAX9UipyNi3QsUCkvg9MA7ZHrxTz/u/aoUHRB+zgSXkdniZpkj4Ag=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.2/OnlyEQ.app.zip" length="2443995" type="application/octet-stream" sparkle:edSignature="i3qRm07IgMBU5ZUW9vAAteRB7Z970nKQYGdg8oa7x3uKvLjDvB3Q7NT97bLiQSiVAPPKr8z1Zi9b55hRDDHSAQ=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.2.2.md
+++ b/release-notes/1.2.2.md
@@ -6,7 +6,8 @@
 - Keeps the menu-bar icon brightly highlighted while the panel is open.
 - Matches EQ-node dragging, spectrum presentation, peak metering, and volume publication to the active display refresh rate, including 120 Hz ProMotion screens.
 - Caches size-independent EQ response data during live window resizing and recalculates only bands whose parameters changed.
-- Prevents editor intrinsic-size feedback while resizing its window.
+- Keeps editor hosting unconstrained so AppKit edge and corner resizing remains available.
 - Fixes the real status-icon click path so the arrowless panel no longer closes immediately when mouse tracking releases key focus.
 - Uses explicit outside-click, app-deactivation, and window-opening dismissal instead of fragile key-window loss.
+- Avoids `hidesOnDeactivate`, which could invisibly order out an accessory-app panel immediately after a real status click; global clicks and workspace activation now own dismissal.
 - Keeps bottom-bar labels, toggles, and buttons intact at narrow editor widths while allowing the preamp slider to shrink fluidly.


### PR DESCRIPTION
## Summary

Restores ordinary edge and corner resizing for the OnlyEQ editor while preserving its responsive minimum-width layout. It also hardens the arrowless menu panel against accessory-app deactivation and makes the UI probe exercise the production editor window path so this regression is caught in future checks.

## Why

The editor's `NSHostingController` used `.standardBounds`, which allowed SwiftUI's sizing preferences to constrain the AppKit window and prevent normal manual resizing. The previous probe created a separate window, so it did not reproduce the production configuration.

## What

- Remove editor-only SwiftUI standard sizing bounds; retain the AppKit `.resizable` style and 720×480 minimum.
- Keep the menu panel visible until an explicit outside click, app activation, or window handoff dismisses it.
- Route editor and profile-suggestion probes through `WindowManager.showEditor`.
- Publish the corrected 1.2.2 archive as internal build 14 with a regenerated signed Sparkle appcast.

## Solution

```mermaid
flowchart LR
  A["Editor or probe request"] --> B["WindowManager.showEditor"]
  B --> C["Resizable NSWindow"]
  C --> D["Unconstrained NSHostingController"]
  D --> E["Native edge and corner resize"]
  F["Status item click"] --> G["Arrowless menu panel"]
  G --> H["Explicit outside-click or app-activation dismissal"]
```

### Review order

1. `Sources/OnlyEQ/App/AppDelegate.swift` — production editor sizing and menu-panel lifecycle.
2. `Sources/OnlyEQ/main.swift` — probe now follows the production window path.
3. `Resources/Info.plist` — internal build 14 update eligibility.
4. `release-notes/1.2.2.md` and `appcast.xml` — release description and signed enclosure metadata.

## Types of Changes

- [x] Bug fix
- [x] Test infrastructure
- [x] Release metadata
- [ ] Breaking change

## Test Plan

- `swift build -Xswiftc -warnings-as-errors`
- `swift run OnlyEQ --test` — 63 passed, 0 failed.
- Production-path editor probe accepted 720×480, 1000×700, and 760×520 exactly.
- Visual check at 760×520 confirmed the bottom bar remains on one line without clipping.
- `./scripts/prepare-release.sh 1.2.2`
- Deep code-signature verification passed for the app and the archive after extraction.
- Universal binary verified with both `arm64` and `x86_64` slices.
- Signed Sparkle appcast verified as version 1.2.2, build 14.

An app-only screenshot was not attached because the available runtime capture included unrelated desktop video content; the visual result was inspected locally.

## Related Issues

No issue was provided; this follows the reported inability to resize the editor.
