### PR TITLE
Stop the periodic CPU blips from the silence watchdog

### DIFF
--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -159,15 +159,20 @@ final class AppState: ObservableObject {
     private func startSilenceWatchdog() {
         guard !Self.screenshotMode else { return }
         silenceCheckTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                guard let self else { return }
-                if self.engine.hasReceivedAudio { self.audioConfirmedThisSession = true }
-                self.suspectedPermissionIssue = self.isEnabled
-                    && self.engineState == .running
-                    && !self.engine.hasReceivedAudio
-                    && !self.audioConfirmedThisSession
-            }
+            Task { @MainActor in self?.silenceWatchdogTick() }
         }
+        silenceCheckTimer?.tolerance = 1
+    }
+
+    func silenceWatchdogTick() {
+        if engine.hasReceivedAudio { audioConfirmedThisSession = true }
+        let suspected = isEnabled
+            && engineState == .running
+            && !engine.hasReceivedAudio
+            && !audioConfirmedThisSession
+        // @Published republishes unchanged values, and every publish re-layouts
+        // each alive (hidden) window's SwiftUI tree — a visible CPU blip per tick.
+        if suspected != suspectedPermissionIssue { suspectedPermissionIssue = suspected }
     }
 
     // MARK: - Devices

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 /// Minimal self-test harness (CLT has no XCTest). Run with `swift run OnlyEQ --test`.
@@ -25,6 +26,7 @@ enum TestRunner {
         do {
             try importerTests()
             dspTests()
+            watchdogTests()
         } catch {
             failures.append("Uncaught error: \(error)")
         }
@@ -190,5 +192,23 @@ enum TestRunner {
         expect(HeadphoneNameMatcher.score(query: "WH-1000XM5", candidate: "Sony WH-1000XM5")
                > HeadphoneNameMatcher.score(query: "WH-1000XM5", candidate: "Sony WH-1000XM4"),
                "headphone matcher prioritizes exact model number")
+    }
+
+    /// Every objectWillChange re-layouts each alive (hidden) window's SwiftUI
+    /// tree, so steady-state watchdog ticks must not publish.
+    private static func watchdogTests() {
+        MainActor.assumeIsolated {
+            AppState.screenshotMode = true  // no engine, no persistence
+            let state = AppState.shared
+            state.engineState = .stopped
+
+            var publishes = 0
+            let subscription = state.objectWillChange.sink { _ in publishes += 1 }
+            withExtendedLifetime(subscription) {
+                state.silenceWatchdogTick()
+                state.silenceWatchdogTick()
+            }
+            expect(publishes == 0, "watchdog ticks publish only on change")
+        }
     }
 }


### PR DESCRIPTION
The silence watchdog (a 3-second timer, in place since 1.0.0) reassigns
suspectedPermissionIssue on every tick. @Published fires objectWillChange
even when the value hasn't changed, so every tick invalidates each alive
SwiftUI tree. That was cheap while the popover was an unshown NSPopover,
but since #8 the menu panel is a real NSWindow that exists from launch,
and closed windows here (panel, editor, settings) are only ordered out,
never released — so every tick now runs a full NSHostingView layout pass
for each of them. Sampling shows ~30–40 ms of layout work per tick, which
reads as a 4–5% CPU spike every three seconds in Activity Monitor,
playing or paused.

Only assign the flag when it actually flips, and give the timer a second
of tolerance so its wakeups can coalesce. Added a check to the test
runner that steady-state watchdog ticks publish nothing.