### PR TITLE
[codex] Integrate and harden Wayne’s fixes

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.2.2</string>
 	<key>CFBundleExecutable</key>

--- a/Sources/OnlyEQ/App/AppDelegate.swift
+++ b/Sources/OnlyEQ/App/AppDelegate.swift
@@ -8,7 +8,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var statusItem: NSStatusItem!
     private var menuPanel: MenuPanel!
     private var localMouseMonitor: Any?
-    private var globalMouseMonitor: Any?
     private var workspaceActivationObserver: NSObjectProtocol?
     private var hidePanelObserver: NSObjectProtocol?
     private let updaterController = SPUStandardUpdaterController(
@@ -77,7 +76,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         if let localMouseMonitor { NSEvent.removeMonitor(localMouseMonitor) }
-        if let globalMouseMonitor { NSEvent.removeMonitor(globalMouseMonitor) }
         if let workspaceActivationObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(workspaceActivationObserver)
         }
@@ -129,12 +127,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             return event
         }
 
-        globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(
-            matching: [.leftMouseDown, .rightMouseDown]
-        ) { [weak self] _ in
-            Task { @MainActor in self?.hideMenuPanel() }
-        }
-
+        // The panel activates this accessory app while open, so an outside
+        // click is represented reliably by another workspace application
+        // becoming active. A global mouse monitor is both redundant and unsafe:
+        // status-item clicks are hosted out of process and appear there before
+        // the button's mouse-up action, which can hide then immediately reopen.
         workspaceActivationObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil, queue: .main

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -116,6 +116,12 @@ final class AppState: ObservableObject {
         engine.onStateChange = { [weak self] state in
             Task { @MainActor in self?.engineState = state }
         }
+        // A nominal sample-rate change (Bluetooth codec renegotiation, Audio
+        // MIDI Setup) invalidates the biquad coefficients; rebuild everything
+        // at the new rate.
+        engine.onSampleRateChange = { [weak self] in
+            Task { @MainActor in self?.rebuildEngine() }
+        }
         rebuildEngine()
         startSilenceWatchdog()
     }

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -89,8 +89,16 @@ final class AppState: ObservableObject {
     @Published var popoverIsVisible = false { didSet { updateVisualizationState() } }
     @Published var editorIsVisible = false { didSet { updateVisualizationState() } }
 
+    /// autoPreamp scans a 512-point response curve; during a band drag this is
+    /// read ~120×/s with unchanged bands, so memoize on the band values.
+    private var autoPreampCache: (bands: [EQBand], value: Double)?
+
     var effectivePreampDB: Double {
-        autoPreampEnabled ? EQResponse.autoPreamp(bands: preset.bands) : preset.preampDB
+        guard autoPreampEnabled else { return preset.preampDB }
+        if let cache = autoPreampCache, cache.bands == preset.bands { return cache.value }
+        let value = EQResponse.autoPreamp(bands: preset.bands)
+        autoPreampCache = (preset.bands, value)
+        return value
     }
 
     var latencyMilliseconds: Int { Int((engine.estimatedLatency * 1000).rounded()) }

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -232,9 +232,17 @@ final class AppState: ObservableObject {
     }
 
     private func handleDefaultDeviceChanged() {
+        let previousUID = currentDevice?.uid
         refreshDevices()
         if isEnabled { rebuildEngine() }
-        applyDeviceProfileIfNeeded()
+        if previousUID != currentDevice?.uid {
+            // Stash the outgoing device's working EQ (including unsaved edits)
+            // so switching back restores it. Duplicate notifications for the
+            // same device must not re-apply anything — that would discard
+            // edits made since the profile was applied.
+            if let previousUID { store.stashWorkingPreset(preset, forDevice: previousUID) }
+            applyDeviceProfileIfNeeded()
+        }
         suggestProfileForCurrentDeviceIfNeeded()
     }
 
@@ -257,8 +265,12 @@ final class AppState: ObservableObject {
 
     private func applyDeviceProfileIfNeeded() {
         guard let device = currentDevice else { return }
-        if let profile = store.deviceProfiles[device.uid], profile.autoApply,
-           let saved = store.resolveProfilePreset(profile) {
+        if let stashed = store.workingPreset(forDevice: device.uid) {
+            // The user's last working state on this device — it already
+            // reflects the profile plus any manual edits made on top of it.
+            preset = stashed
+        } else if let profile = store.deviceProfiles[device.uid], profile.autoApply,
+                  let saved = store.resolveProfilePreset(profile) {
             preset = saved
         } else {
             // No usable assignment for the new device — reset to flat rather
@@ -295,6 +307,9 @@ final class AppState: ObservableObject {
         store.save(preset)
         store.setProfile(deviceUID: suggestion.deviceUID, deviceName: suggestion.deviceName,
                          preset: preset, autoApply: true)
+        // An explicit assignment beats whatever working state was stashed for
+        // the device — otherwise the stash would shadow it on next connect.
+        store.stashWorkingPreset(preset, forDevice: suggestion.deviceUID)
         if currentDevice?.uid == suggestion.deviceUID {
             self.preset = preset
             presetWasAutoApplied = true

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -165,15 +165,20 @@ final class AppState: ObservableObject {
     private func startSilenceWatchdog() {
         guard !Self.screenshotMode else { return }
         silenceCheckTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                guard let self else { return }
-                if self.engine.hasReceivedAudio { self.audioConfirmedThisSession = true }
-                self.suspectedPermissionIssue = self.isEnabled
-                    && self.engineState == .running
-                    && !self.engine.hasReceivedAudio
-                    && !self.audioConfirmedThisSession
-            }
+            Task { @MainActor in self?.silenceWatchdogTick() }
         }
+        silenceCheckTimer?.tolerance = 1
+    }
+
+    func silenceWatchdogTick() {
+        if engine.hasReceivedAudio { audioConfirmedThisSession = true }
+        let suspected = isEnabled
+            && engineState == .running
+            && !engine.hasReceivedAudio
+            && !audioConfirmedThisSession
+        // @Published republishes unchanged values, and every publish re-layouts
+        // each alive (hidden) window's SwiftUI tree — a visible CPU blip per tick.
+        if suspected != suspectedPermissionIssue { suspectedPermissionIssue = suspected }
     }
 
     // MARK: - Devices

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -91,13 +91,15 @@ final class AppState: ObservableObject {
 
     /// autoPreamp scans a 512-point response curve; during a band drag this is
     /// read ~120×/s with unchanged bands, so memoize on the band values.
-    private var autoPreampCache: (bands: [EQBand], value: Double)?
+    private var autoPreampCache: (bands: [EQBand], sampleRate: Double, value: Double)?
 
     var effectivePreampDB: Double {
         guard autoPreampEnabled else { return preset.preampDB }
-        if let cache = autoPreampCache, cache.bands == preset.bands { return cache.value }
-        let value = EQResponse.autoPreamp(bands: preset.bands)
-        autoPreampCache = (preset.bands, value)
+        let sampleRate = engine.processor.sampleRate
+        if let cache = autoPreampCache,
+           cache.bands == preset.bands, cache.sampleRate == sampleRate { return cache.value }
+        let value = EQResponse.autoPreamp(bands: preset.bands, sampleRate: sampleRate)
+        autoPreampCache = (preset.bands, sampleRate, value)
         return value
     }
 
@@ -106,6 +108,9 @@ final class AppState: ObservableObject {
     private var deviceListenerInstalled = false
     private var silenceCheckTimer: Timer?
     private var pendingPresetPersistence: DispatchWorkItem?
+    private var pendingPresetSnapshot: (deviceUID: String, preset: EQPreset)?
+    private var isRestoringWorkingPreset = false
+    private var sampleRateRebuildScheduled = false
     private var suggestedDeviceUIDs = Set(UserDefaults.standard.stringArray(forKey: "profileSuggestion.seenDeviceUIDs") ?? [])
     private var currentDeviceHasHardwareVolume = false
     private var lastPushedSoftwareGainDB = Double.nan
@@ -118,8 +123,8 @@ final class AppState: ObservableObject {
     // MARK: - Setup
 
     private init() {
-        restoreWorkingPreset()
         refreshDevices()
+        restoreWorkingPresetForCurrentDevice(migrateLegacyPreset: true)
         installDeviceListeners()
         engine.onStateChange = { [weak self] state in
             Task { @MainActor in self?.engineState = state }
@@ -128,7 +133,7 @@ final class AppState: ObservableObject {
         // MIDI Setup) invalidates the biquad coefficients; rebuild everything
         // at the new rate.
         engine.onSampleRateChange = { [weak self] in
-            Task { @MainActor in self?.rebuildEngine() }
+            Task { @MainActor in self?.scheduleSampleRateRebuild() }
         }
         rebuildEngine()
         startSilenceWatchdog()
@@ -147,6 +152,19 @@ final class AppState: ObservableObject {
             engine.stop()
         }
         refreshDevices()
+    }
+
+    private func scheduleSampleRateRebuild() {
+        guard !sampleRateRebuildScheduled else { return }
+        sampleRateRebuildScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.sampleRateRebuildScheduled = false
+            let deviceID = self.engine.targetDeviceID
+            guard self.isEnabled, self.engine.state == .running, deviceID != 0,
+                  AudioDeviceManager.nominalSampleRate(deviceID) != self.engine.processor.sampleRate else { return }
+            self.rebuildEngine()
+        }
     }
 
     private func pushToProcessor() {
@@ -232,18 +250,17 @@ final class AppState: ObservableObject {
     }
 
     private func handleDefaultDeviceChanged() {
+        let previousID = currentDevice?.id
         let previousUID = currentDevice?.uid
+        // Commit the outgoing device snapshot before refresh changes the UID
+        // that future edits belong to.
+        flushWorkingPresetPersistence()
         refreshDevices()
-        if isEnabled { rebuildEngine() }
+        if isEnabled, previousID != currentDevice?.id { rebuildEngine() }
         if previousUID != currentDevice?.uid {
-            // Stash the outgoing device's working EQ (including unsaved edits)
-            // so switching back restores it. Duplicate notifications for the
-            // same device must not re-apply anything — that would discard
-            // edits made since the profile was applied.
-            if let previousUID { store.stashWorkingPreset(preset, forDevice: previousUID) }
-            applyDeviceProfileIfNeeded()
+            restoreWorkingPresetForCurrentDevice()
+            suggestProfileForCurrentDeviceIfNeeded()
         }
-        suggestProfileForCurrentDeviceIfNeeded()
     }
 
     private func suggestProfileForCurrentDeviceIfNeeded() {
@@ -263,22 +280,36 @@ final class AppState: ObservableObject {
                                               searchQuery: query))
     }
 
-    private func applyDeviceProfileIfNeeded() {
+    private func restoreWorkingPresetForCurrentDevice(migrateLegacyPreset: Bool = false) {
+        guard !Self.screenshotMode else { return }
         guard let device = currentDevice else { return }
-        if let stashed = store.workingPreset(forDevice: device.uid) {
-            // The user's last working state on this device — it already
-            // reflects the profile plus any manual edits made on top of it.
-            preset = stashed
+        let restored: EQPreset
+        let wasAutoApplied: Bool
+        if let working = store.workingPreset(forDevice: device.uid) {
+            restored = working
+            wasAutoApplied = false
+        } else if migrateLegacyPreset,
+                  let data = UserDefaults.standard.data(forKey: "workingPreset"),
+                  let legacy = try? JSONDecoder().decode(EQPreset.self, from: data) {
+            // Build 14 and earlier stored one global snapshot. Associate it
+            // with the device active during the one-time migration.
+            restored = legacy
+            wasAutoApplied = false
+            store.stashWorkingPreset(legacy, forDevice: device.uid)
+            UserDefaults.standard.removeObject(forKey: "workingPreset")
         } else if let profile = store.deviceProfiles[device.uid], profile.autoApply,
                   let saved = store.resolveProfilePreset(profile) {
-            preset = saved
+            restored = saved
+            wasAutoApplied = true
         } else {
-            // No usable assignment for the new device — reset to flat rather
-            // than carrying the previous device's EQ across (a headphone
-            // correction curve applied to speakers sounds wrong).
-            preset = .flat
+            // Never carry a headphone correction curve onto another output.
+            restored = .flat
+            wasAutoApplied = true
         }
-        presetWasAutoApplied = true
+        isRestoringWorkingPreset = true
+        preset = restored
+        isRestoringWorkingPreset = false
+        presetWasAutoApplied = wasAutoApplied
     }
 
     // MARK: - Presets
@@ -370,10 +401,13 @@ final class AppState: ObservableObject {
     // MARK: - Working preset persistence
 
     private func persistWorkingPreset() {
-        guard !Self.screenshotMode else { return }
+        guard !Self.screenshotMode, !isRestoringWorkingPreset,
+              let deviceUID = currentDevice?.uid else { return }
         pendingPresetPersistence?.cancel()
+        let snapshot = preset
+        pendingPresetSnapshot = (deviceUID, snapshot)
         let work = DispatchWorkItem { [weak self] in
-            self?.writeWorkingPreset()
+            self?.store.stashWorkingPreset(snapshot, forDevice: deviceUID)
         }
         pendingPresetPersistence = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: work)
@@ -385,19 +419,12 @@ final class AppState: ObservableObject {
         guard !Self.screenshotMode else { return }
         pendingPresetPersistence?.cancel()
         pendingPresetPersistence = nil
-        writeWorkingPreset()
-    }
-
-    private func writeWorkingPreset() {
-        if let data = try? JSONEncoder().encode(preset) {
-            UserDefaults.standard.set(data, forKey: "workingPreset")
-        }
-    }
-
-    private func restoreWorkingPreset() {
-        if let data = UserDefaults.standard.data(forKey: "workingPreset"),
-           let saved = try? JSONDecoder().decode(EQPreset.self, from: data) {
-            preset = saved
+        if let pendingPresetSnapshot {
+            store.stashWorkingPreset(pendingPresetSnapshot.preset,
+                                     forDevice: pendingPresetSnapshot.deviceUID)
+            self.pendingPresetSnapshot = nil
+        } else if let deviceUID = currentDevice?.uid {
+            store.stashWorkingPreset(preset, forDevice: deviceUID)
         }
     }
 }

--- a/Sources/OnlyEQ/Audio/EQProcessor.swift
+++ b/Sources/OnlyEQ/Audio/EQProcessor.swift
@@ -58,6 +58,14 @@ final class EQProcessor {
         }
     }
 
+    /// Audio thread only. Clear filter and limiter history before the engine
+    /// enters its prolonged-silence fast path. Keeping the existing storage
+    /// avoids allocating from the realtime callback.
+    func resetRenderState() {
+        for index in states.indices { states[index] = BiquadState() }
+        limiterEnvelope = 0
+    }
+
     /// Called from the UI/model thread whenever parameters change.
     func update(bands: [EQBand], preampDB: Double, outputGainDB: Double = 0,
                 limiterEnabled: Bool, limiterCeilingDB: Double, bypassed: Bool) {

--- a/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
+++ b/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
@@ -43,6 +43,8 @@ final class ProcessTapEngine {
     }
     private var inputChannels: [InputChannel] = []
     private var activeChannels: [UnsafeMutablePointer<Float>] = []
+    /// Consecutive all-zero input frames, saturated at one second's worth.
+    private var silentFrames = 0
 
     var onStateChange: ((State) -> Void)?
 
@@ -132,6 +134,7 @@ final class ProcessTapEngine {
 
         // 3. IOProc: tapped audio arrives as input, processed audio leaves as output.
         hasReceivedAudio = false
+        silentFrames = 0
         status = AudioDeviceCreateIOProcIDWithBlock(&ioProcID, aggregateID, nil) { [weak self] _, inInputData, _, outOutputData, _ in
             self?.render(input: inInputData, output: outOutputData)
         }
@@ -244,7 +247,7 @@ final class ProcessTapEngine {
 
     // MARK: - Render path (audio thread)
 
-    private func render(input: UnsafePointer<AudioBufferList>, output: UnsafeMutablePointer<AudioBufferList>) {
+    func render(input: UnsafePointer<AudioBufferList>, output: UnsafeMutablePointer<AudioBufferList>) {
         let inputList = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: input))
         let outputList = UnsafeMutableAudioBufferListPointer(output)
         guard inputList.count > 0, outputList.count > 0 else { return }
@@ -265,12 +268,31 @@ final class ProcessTapEngine {
         }
         guard !inputChannels.isEmpty, frameCount != .max, frameCount > 0 else { return }
 
-        if !hasReceivedAudio {
-            outer: for channel in inputChannels {
-                for i in 0..<min(frameCount, 64) where channel.pointer[i * channel.stride] != 0 {
-                    hasReceivedAudio = true
-                    break outer
+        // One peak scan of the raw input detects audio anywhere in the buffer,
+        // and a full ring-out window of exact silence means the EQ and limiter
+        // tails have decayed too — the DSP chain can idle until audio returns.
+        var inputPeak: Float = 0
+        for buffer in inputList {
+            guard let data = buffer.mData else { continue }
+            let count = Int(buffer.mDataByteSize) / MemoryLayout<Float>.size
+            guard count > 0 else { continue }
+            var peak: Float = 0
+            vDSP_maxmgv(data.assumingMemoryBound(to: Float.self), 1, &peak, vDSP_Length(count))
+            inputPeak = max(inputPeak, peak)
+        }
+        if inputPeak != 0 {
+            hasReceivedAudio = true
+            silentFrames = 0
+        } else {
+            let ringOutFrames = Int(processor.sampleRate)
+            silentFrames = min(silentFrames + frameCount, ringOutFrames)
+            if silentFrames == ringOutFrames {
+                for buffer in outputList {
+                    guard let data = buffer.mData else { continue }
+                    vDSP_vclr(data.assumingMemoryBound(to: Float.self), 1,
+                              vDSP_Length(Int(buffer.mDataByteSize) / MemoryLayout<Float>.size))
                 }
+                return
             }
         }
 

--- a/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
+++ b/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
@@ -35,6 +35,7 @@ final class ProcessTapEngine {
     private var tapID: AudioObjectID = 0
     private var aggregateID: AudioObjectID = 0
     private var ioProcID: AudioDeviceIOProcID?
+    private var sampleRateListener: AudioObjectPropertyListenerBlock?
     private var channelScratch: [UnsafeMutablePointer<Float>] = []
     private struct InputChannel {
         var pointer: UnsafeMutablePointer<Float>
@@ -44,6 +45,11 @@ final class ProcessTapEngine {
     private var activeChannels: [UnsafeMutablePointer<Float>] = []
 
     var onStateChange: ((State) -> Void)?
+
+    /// Fired (on the main queue) when the tapped device's nominal sample rate
+    /// changes while running. Biquad coefficients are baked for one rate, so
+    /// the owner must restart the engine to stay on pitch.
+    var onSampleRateChange: (() -> Void)?
 
     init() {
         inputChannels.reserveCapacity(8)
@@ -147,10 +153,12 @@ final class ProcessTapEngine {
             return
         }
 
+        installSampleRateListener(on: deviceID)
         transition(to: .running)
     }
 
     func stop() {
+        removeSampleRateListener()
         if let ioProcID, aggregateID != 0 {
             AudioDeviceStop(aggregateID, ioProcID)
             AudioDeviceDestroyIOProcID(aggregateID, ioProcID)
@@ -185,6 +193,30 @@ final class ProcessTapEngine {
         Log.write("engine: \(newState)")
         let callback = onStateChange
         DispatchQueue.main.async { callback?(newState) }
+    }
+
+    private static let sampleRateAddress = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyNominalSampleRate,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain)
+
+    private func installSampleRateListener(on deviceID: AudioObjectID) {
+        let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            guard let self,
+                  AudioDeviceManager.nominalSampleRate(deviceID) != self.processor.sampleRate else { return }
+            self.onSampleRateChange?()
+        }
+        var addr = Self.sampleRateAddress
+        if AudioObjectAddPropertyListenerBlock(deviceID, &addr, .main, block) == noErr {
+            sampleRateListener = block
+        }
+    }
+
+    private func removeSampleRateListener() {
+        guard let sampleRateListener, targetDeviceID != 0 else { return }
+        var addr = Self.sampleRateAddress
+        AudioObjectRemovePropertyListenerBlock(targetDeviceID, &addr, .main, sampleRateListener)
+        self.sampleRateListener = nil
     }
 
     private func readIOBufferSize() {

--- a/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
+++ b/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
@@ -214,6 +214,11 @@ final class ProcessTapEngine {
         var addr = Self.sampleRateAddress
         if AudioObjectAddPropertyListenerBlock(deviceID, &addr, .main, block) == noErr {
             sampleRateListener = block
+            // Close the small gap between the initial rate read and listener
+            // installation: a device can renegotiate while the aggregate starts.
+            if AudioDeviceManager.nominalSampleRate(deviceID) != processor.sampleRate {
+                onSampleRateChange?()
+            }
         }
     }
 

--- a/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
+++ b/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
@@ -45,6 +45,7 @@ final class ProcessTapEngine {
     private var activeChannels: [UnsafeMutablePointer<Float>] = []
     /// Consecutive all-zero input frames, saturated at one second's worth.
     private var silentFrames = 0
+    private var isSilenceGated = false
 
     var onStateChange: ((State) -> Void)?
 
@@ -135,6 +136,7 @@ final class ProcessTapEngine {
         // 3. IOProc: tapped audio arrives as input, processed audio leaves as output.
         hasReceivedAudio = false
         silentFrames = 0
+        isSilenceGated = false
         status = AudioDeviceCreateIOProcIDWithBlock(&ioProcID, aggregateID, nil) { [weak self] _, inInputData, _, outOutputData, _ in
             self?.render(input: inInputData, output: outOutputData)
         }
@@ -283,10 +285,15 @@ final class ProcessTapEngine {
         if inputPeak != 0 {
             hasReceivedAudio = true
             silentFrames = 0
+            isSilenceGated = false
         } else {
             let ringOutFrames = Int(processor.sampleRate)
             silentFrames = min(silentFrames + frameCount, ringOutFrames)
             if silentFrames == ringOutFrames {
+                if !isSilenceGated {
+                    processor.resetRenderState()
+                    isSilenceGated = true
+                }
                 for buffer in outputList {
                     guard let data = buffer.mData else { continue }
                     vDSP_vclr(data.assumingMemoryBound(to: Float.self), 1,

--- a/Sources/OnlyEQ/Models/PresetStore.swift
+++ b/Sources/OnlyEQ/Models/PresetStore.swift
@@ -7,9 +7,15 @@ final class PresetStore: ObservableObject {
     @Published private(set) var customPresets: [EQPreset] = []
     @Published var deviceProfiles: [String: DeviceProfile] = [:]  // keyed by device UID
 
+    /// Working (possibly unsaved) EQ state per device UID, stashed on output
+    /// switches so returning to a device restores manual edits instead of
+    /// discarding them.
+    private var workingPresets: [String: EQPreset] = [:]
+
     private let directory: URL
     private var presetsURL: URL { directory.appendingPathComponent("presets.json") }
     private var profilesURL: URL { directory.appendingPathComponent("profiles.json") }
+    private var workingURL: URL { directory.appendingPathComponent("working-presets.json") }
 
     var allPresets: [EQPreset] { EQPreset.builtIns + customPresets }
 
@@ -56,6 +62,15 @@ final class PresetStore: ObservableObject {
         persist()
     }
 
+    func stashWorkingPreset(_ preset: EQPreset, forDevice uid: String) {
+        workingPresets[uid] = preset
+        persist()
+    }
+
+    func workingPreset(forDevice uid: String) -> EQPreset? {
+        workingPresets[uid]
+    }
+
     func setProfile(deviceUID: String, deviceName: String, preset: EQPreset?, autoApply: Bool = true) {
         deviceProfiles[deviceUID] = DeviceProfile(
             deviceUID: deviceUID, deviceName: deviceName,
@@ -75,6 +90,10 @@ final class PresetStore: ObservableObject {
            let profiles = try? JSONDecoder().decode([String: DeviceProfile].self, from: data) {
             deviceProfiles = profiles
         }
+        if let data = try? Data(contentsOf: workingURL),
+           let working = try? JSONDecoder().decode([String: EQPreset].self, from: data) {
+            workingPresets = working
+        }
     }
 
     private func persist() {
@@ -82,5 +101,6 @@ final class PresetStore: ObservableObject {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         try? encoder.encode(customPresets).write(to: presetsURL, options: .atomic)
         try? encoder.encode(deviceProfiles).write(to: profilesURL, options: .atomic)
+        try? encoder.encode(workingPresets).write(to: workingURL, options: .atomic)
     }
 }

--- a/Sources/OnlyEQ/Models/PresetStore.swift
+++ b/Sources/OnlyEQ/Models/PresetStore.swift
@@ -63,8 +63,9 @@ final class PresetStore: ObservableObject {
     }
 
     func stashWorkingPreset(_ preset: EQPreset, forDevice uid: String) {
+        guard workingPresets[uid] != preset else { return }
         workingPresets[uid] = preset
-        persist()
+        persistWorkingPresets()
     }
 
     func workingPreset(forDevice uid: String) -> EQPreset? {
@@ -101,6 +102,12 @@ final class PresetStore: ObservableObject {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         try? encoder.encode(customPresets).write(to: presetsURL, options: .atomic)
         try? encoder.encode(deviceProfiles).write(to: profilesURL, options: .atomic)
+        try? encoder.encode(workingPresets).write(to: workingURL, options: .atomic)
+    }
+
+    private func persistWorkingPresets() {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         try? encoder.encode(workingPresets).write(to: workingURL, options: .atomic)
     }
 }

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -1,4 +1,5 @@
 import Combine
+import CoreAudio
 import Foundation
 
 /// Minimal self-test harness (CLT has no XCTest). Run with `swift run OnlyEQ --test`.
@@ -27,6 +28,8 @@ enum TestRunner {
             try importerTests()
             dspTests()
             watchdogTests()
+            engineRenderTests()
+            appStateTests()
         } catch {
             failures.append("Uncaught error: \(error)")
         }
@@ -209,6 +212,85 @@ enum TestRunner {
                 state.silenceWatchdogTick()
             }
             expect(publishes == 0, "watchdog ticks publish only on change")
+        }
+    }
+
+    /// Wraps interleaved sample storage in single-buffer AudioBufferLists and
+    /// drives the engine's render callback directly, without Core Audio.
+    private static func renderOnce(_ engine: ProcessTapEngine, channels: Int,
+                                   input: inout [Float], output: inout [Float]) {
+        input.withUnsafeMutableBufferPointer { inBuf in
+            output.withUnsafeMutableBufferPointer { outBuf in
+                var inputList = AudioBufferList(
+                    mNumberBuffers: 1,
+                    mBuffers: AudioBuffer(mNumberChannels: UInt32(channels),
+                                          mDataByteSize: UInt32(inBuf.count * MemoryLayout<Float>.size),
+                                          mData: UnsafeMutableRawPointer(inBuf.baseAddress)))
+                var outputList = AudioBufferList(
+                    mNumberBuffers: 1,
+                    mBuffers: AudioBuffer(mNumberChannels: UInt32(channels),
+                                          mDataByteSize: UInt32(outBuf.count * MemoryLayout<Float>.size),
+                                          mData: UnsafeMutableRawPointer(outBuf.baseAddress)))
+                engine.render(input: &inputList, output: &outputList)
+            }
+        }
+    }
+
+    private static func engineRenderTests() {
+        let frames = 512, channels = 2
+
+        // Audio starting later in the buffer must still mark the tap as live.
+        let lateEngine = ProcessTapEngine()
+        var lateInput = [Float](repeating: 0, count: frames * channels)
+        for frame in 100..<frames { lateInput[frame * channels] = 0.5 }
+        var output = [Float](repeating: 0, count: frames * channels)
+        renderOnce(lateEngine, channels: channels, input: &lateInput, output: &output)
+        expect(lateEngine.hasReceivedAudio, "render detects audio past the first 64 frames")
+
+        // After a full ring-out window of exact silence the output stays zeroed
+        // and the tap is still not considered live.
+        let engine = ProcessTapEngine()
+        var silence = [Float](repeating: 0, count: frames * channels)
+        for _ in 0...(Int(engine.processor.sampleRate) / frames + 1) {
+            renderOnce(engine, channels: channels, input: &silence, output: &output)
+        }
+        var staleOutput = [Float](repeating: 0.7, count: frames * channels)
+        renderOnce(engine, channels: channels, input: &silence, output: &staleOutput)
+        expect(staleOutput.allSatisfy { $0 == 0 }, "silent input renders silent output after ring-out")
+        expect(!engine.hasReceivedAudio, "pure silence never marks the tap as live")
+
+        // The first non-silent buffer after prolonged silence passes through
+        // immediately (no dropout from the idle path).
+        var tone = (0..<frames * channels).map {
+            Float(0.5 * sin(Double($0 / channels) * 2 * .pi * 440 / 48000))
+        }
+        var resumed = [Float](repeating: 0, count: frames * channels)
+        renderOnce(engine, channels: channels, input: &tone, output: &resumed)
+        expect((resumed.map(abs).max() ?? 0) > 0.4, "audio resumes immediately after prolonged silence")
+        expect(engine.hasReceivedAudio, "resumed audio marks the tap as live")
+    }
+
+    private static func appStateTests() {
+        MainActor.assumeIsolated {
+            AppState.screenshotMode = true  // no engine, no persistence
+            let state = AppState.shared
+            let savedPreset = state.preset
+            let savedAuto = state.autoPreampEnabled
+            defer {
+                state.preset = savedPreset
+                state.autoPreampEnabled = savedAuto
+            }
+
+            state.autoPreampEnabled = true
+            state.preset = EQPreset(name: "Auto A", bands: [EQBand(type: .peak, frequency: 1000, gain: 5, q: 1.41)])
+            expect(near(state.effectivePreampDB, -5, 0.1), "effective preamp follows auto preamp")
+            expect(near(state.effectivePreampDB, state.effectivePreampDB), "repeated reads are stable")
+            state.preset = EQPreset(name: "Auto B", bands: [EQBand(type: .peak, frequency: 1000, gain: 8, q: 1.41)])
+            expect(near(state.effectivePreampDB, -8, 0.1), "effective preamp tracks band edits")
+
+            state.autoPreampEnabled = false
+            state.preset.preampDB = -3
+            expect(state.effectivePreampDB == -3, "manual preamp used when auto is off")
         }
     }
 }

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -259,6 +259,25 @@ enum TestRunner {
         expect(staleOutput.allSatisfy { $0 == 0 }, "silent input renders silent output after ring-out")
         expect(!engine.hasReceivedAudio, "pure silence never marks the tap as live")
 
+        // Entering the idle path must discard filter/limiter history. Otherwise
+        // stale state from a second earlier can leak into the first resumed buffer.
+        let stateProcessor = EQProcessor()
+        stateProcessor.configure(sampleRate: 48_000)
+        stateProcessor.update(
+            bands: [EQBand(type: .peak, frequency: 40, gain: 12, q: 20)],
+            preampDB: 0, limiterEnabled: true, limiterCeilingDB: -1, bypassed: false
+        )
+        var primingTone = (0..<512).map { Float(sin(Double($0) * 2 * .pi * 40 / 48_000)) }
+        primingTone.withUnsafeMutableBufferPointer {
+            stateProcessor.process(channels: [$0.baseAddress!], frameCount: $0.count)
+        }
+        stateProcessor.resetRenderState()
+        var resetSilence = [Float](repeating: 0, count: 512)
+        resetSilence.withUnsafeMutableBufferPointer {
+            stateProcessor.process(channels: [$0.baseAddress!], frameCount: $0.count)
+        }
+        expect(resetSilence.allSatisfy { $0 == 0 }, "silence gate clears realtime DSP history")
+
         // The first non-silent buffer after prolonged silence passes through
         // immediately (no dropout from the idle path).
         var tone = (0..<frames * channels).map {

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 /// Minimal self-test harness (CLT has no XCTest). Run with `swift run OnlyEQ --test`.
@@ -25,6 +26,7 @@ enum TestRunner {
         do {
             try importerTests()
             dspTests()
+            watchdogTests()
         } catch {
             failures.append("Uncaught error: \(error)")
         }
@@ -190,5 +192,23 @@ enum TestRunner {
         expect(HeadphoneNameMatcher.score(query: "WH-1000XM5", candidate: "Sony WH-1000XM5")
                > HeadphoneNameMatcher.score(query: "WH-1000XM5", candidate: "Sony WH-1000XM4"),
                "headphone matcher prioritizes exact model number")
+    }
+
+    /// Every objectWillChange re-layouts each alive (hidden) window's SwiftUI
+    /// tree, so steady-state watchdog ticks must not publish.
+    private static func watchdogTests() {
+        MainActor.assumeIsolated {
+            AppState.screenshotMode = true  // no engine, no persistence
+            let state = AppState.shared
+            state.engineState = .stopped
+
+            var publishes = 0
+            let subscription = state.objectWillChange.sink { _ in publishes += 1 }
+            withExtendedLifetime(subscription) {
+                state.silenceWatchdogTick()
+                state.silenceWatchdogTick()
+            }
+            expect(publishes == 0, "watchdog ticks publish only on change")
+        }
     }
 }

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -30,6 +30,7 @@ enum TestRunner {
             watchdogTests()
             engineRenderTests()
             appStateTests()
+            storeTests()
         } catch {
             failures.append("Uncaught error: \(error)")
         }
@@ -117,6 +118,28 @@ enum TestRunner {
         let data = try JSONEncoder().encode(original)
         r = try PresetImporter.importData(data)
         expect(r.detectedFormat == "OnlyEQ preset" && r.preset == original, "native round trip")
+    }
+
+    private static func storeTests() {
+        // `--test` runs on the main thread (see main.swift), so touching the
+        // MainActor-isolated PresetStore directly is safe.
+        MainActor.assumeIsolated {
+            let dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("OnlyEQ-tests-\(UUID().uuidString)", isDirectory: true)
+            defer { try? FileManager.default.removeItem(at: dir) }
+
+            let edited = EQPreset(name: "Working", preampDB: -3, bands: [
+                EQBand(type: .peak, frequency: 3000, gain: -4, q: 2),
+            ])
+            let store = PresetStore(directory: dir)
+            expect(store.workingPreset(forDevice: "uid-a") == nil, "no working preset for unknown device")
+            store.stashWorkingPreset(edited, forDevice: "uid-a")
+            expect(store.workingPreset(forDevice: "uid-a") == edited, "working preset stash round trip")
+            expect(store.workingPreset(forDevice: "uid-b") == nil, "stash is keyed by device UID")
+
+            let reloaded = PresetStore(directory: dir)
+            expect(reloaded.workingPreset(forDevice: "uid-a") == edited, "working preset stash persists to disk")
+        }
     }
 
     private static func dspTests() {

--- a/appcast.xml
+++ b/appcast.xml
@@ -4,9 +4,9 @@
         <title>OnlyEQ</title>
         <item>
             <title>1.2.2</title>
-            <pubDate>Thu, 09 Jul 2026 22:19:11 -0700</pubDate>
+            <pubDate>Fri, 10 Jul 2026 11:23:54 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>14</sparkle:version>
+            <sparkle:version>15</sparkle:version>
             <sparkle:shortVersionString>1.2.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
             <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.2
@@ -20,10 +20,15 @@
 - Keeps editor hosting unconstrained so AppKit edge and corner resizing remains available.
 - Fixes the real status-icon click path so the arrowless panel no longer closes immediately when mouse tracking releases key focus.
 - Uses explicit outside-click, app-deactivation, and window-opening dismissal instead of fragile key-window loss.
-- Avoids `hidesOnDeactivate`, which could invisibly order out an accessory-app panel immediately after a real status click; global clicks and workspace activation now own dismissal.
+- Avoids `hidesOnDeactivate` and the race-prone global mouse monitor; local window events and workspace activation now own dismissal.
 - Keeps bottom-bar labels, toggles, and buttons intact at narrow editor widths while allowing the preamp slider to shrink fluidly.
+- Rebuilds the audio engine when an output device renegotiates its sample rate, keeping filters and spectrum bins correctly tuned.
+- Stops DSP processing after prolonged digital silence, clears stale filter and limiter history before sleeping, and resumes on the first non-silent buffer.
+- Memoizes automatic preamp calculations by band values and active sample rate.
+- Eliminates periodic hidden-window layout spikes from unchanged permission-watchdog publications.
+- Remembers independent working EQ state for each output device without writing on every drag frame.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.2/OnlyEQ.app.zip" length="2443995" type="application/octet-stream" sparkle:edSignature="i3qRm07IgMBU5ZUW9vAAteRB7Z970nKQYGdg8oa7x3uKvLjDvB3Q7NT97bLiQSiVAPPKr8z1Zi9b55hRDDHSAQ=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.2/OnlyEQ.app.zip" length="2474268" type="application/octet-stream" sparkle:edSignature="Y765laLqS5SWRj/rIlgvwLNtSZYPsphjhJFtrhNLXzl2Y4nBmxDG+JD9GEZ4tcA2+02d38zxCHfMijBwkkzuCw=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.2.2.md
+++ b/release-notes/1.2.2.md
@@ -9,5 +9,10 @@
 - Keeps editor hosting unconstrained so AppKit edge and corner resizing remains available.
 - Fixes the real status-icon click path so the arrowless panel no longer closes immediately when mouse tracking releases key focus.
 - Uses explicit outside-click, app-deactivation, and window-opening dismissal instead of fragile key-window loss.
-- Avoids `hidesOnDeactivate`, which could invisibly order out an accessory-app panel immediately after a real status click; global clicks and workspace activation now own dismissal.
+- Avoids `hidesOnDeactivate` and the race-prone global mouse monitor; local window events and workspace activation now own dismissal.
 - Keeps bottom-bar labels, toggles, and buttons intact at narrow editor widths while allowing the preamp slider to shrink fluidly.
+- Rebuilds the audio engine when an output device renegotiates its sample rate, keeping filters and spectrum bins correctly tuned.
+- Stops DSP processing after prolonged digital silence, clears stale filter and limiter history before sleeping, and resumes on the first non-silent buffer.
+- Memoizes automatic preamp calculations by band values and active sample rate.
+- Eliminates periodic hidden-window layout spikes from unchanged permission-watchdog publications.
+- Remembers independent working EQ state for each output device without writing on every drag frame.


### PR DESCRIPTION
## Summary

Integrates the necessary parts of Wayne's open work on current `main`, preserving his authorship on the adopted commits while hardening the realtime and persistence paths.

## What changed

- Track output-device nominal sample-rate changes and coalesce engine rebuilds so EQ coefficients, spectrum bins, and latency remain correct.
- Stop unchanged silence-watchdog values from republishing and relayouting hidden SwiftUI windows.
- Gate the DSP chain after one second of exact digital silence, explicitly clearing filter/limiter history before sleeping and resuming on the first nonzero buffer.
- Memoize auto-preamp by bands and active sample rate.
- Persist debounced working presets per output-device UID, including one-time migration from the prior global snapshot.
- Remove the global mouse monitor that races the out-of-process status item; outside-app activation and local-window events retain dismissal while preserving the arrowless panel.

## Evaluation

Adopts and supersedes the implementation work in #10, #12, #13, and #17.

PR #11 is intentionally excluded. On the repository GraphicEQ fixture, its 31 direct sampled filters increased RMS reconstruction error from 0.916 dB to 1.179 dB while increasing realtime filters from 10 to 31. It needs a fitted/adaptive design rather than direct sampled gains.

Closes #18.

## Validation

- `swift build -Xswiftc -warnings-as-errors`
- `swift run OnlyEQ --test` — 78 passed, 0 failed
- Warnings-as-errors release builds for arm64 and x86_64
- Universal app deep-signature verification
- Real engine probe: running, audio received, 48 kHz
- Hidden release-build CPU: 12 one-second samples, 0.0–0.2%, 0.17% average
- 102 alternating status-panel transitions with zero adjacent duplicates
- Outside-app activation dismissed the panel correctly
- Signed OnlyEQ 1.2.2 build 15 Sparkle archive: `22a7108057c0692cc3913c47b4c56122396044c302e57dae5f1905ecbad68831`
