### PR TITLE
Fix audio resume after silence

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>16</string>
+	<string>17</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.2.3</string>
 	<key>CFBundleExecutable</key>

--- a/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
+++ b/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
@@ -275,19 +275,18 @@ final class ProcessTapEngine {
         }
         guard !inputChannels.isEmpty, frameCount != .max, frameCount > 0 else { return }
 
-        // One peak scan of the raw input detects audio anywhere in the buffer,
-        // and a full ring-out window of exact silence means the EQ and limiter
-        // tails have decayed too — the DSP chain can idle until audio returns.
-        var inputPeak: Float = 0
-        for buffer in inputList {
-            guard let data = buffer.mData else { continue }
-            let count = Int(buffer.mDataByteSize) / MemoryLayout<Float>.size
-            guard count > 0 else { continue }
-            var peak: Float = 0
-            vDSP_maxmgv(data.assumingMemoryBound(to: Float.self), 1, &peak, vDSP_Length(count))
-            inputPeak = max(inputPeak, peak)
+        // Inspect the exact frames/channels the renderer consumes. Scanning the
+        // raw AudioBuffer storage as one contiguous vDSP vector is incorrect for
+        // layouts with padding or a channel stride and can leave the engine
+        // permanently gated after playback resumes.
+        var inputHasSignal = false
+        signalSearch: for channel in inputChannels {
+            for frame in 0..<frameCount where channel.pointer[frame * channel.stride] != 0 {
+                inputHasSignal = true
+                break signalSearch
+            }
         }
-        if inputPeak != 0 {
+        if inputHasSignal {
             hasReceivedAudio = true
             silentFrames = 0
             isSilenceGated = false

--- a/appcast.xml
+++ b/appcast.xml
@@ -4,21 +4,22 @@
         <title>OnlyEQ</title>
         <item>
             <title>1.2.3</title>
-            <pubDate>Fri, 10 Jul 2026 11:29:23 -0700</pubDate>
+            <pubDate>Fri, 10 Jul 2026 13:29:41 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>16</sparkle:version>
+            <sparkle:version>17</sparkle:version>
             <sparkle:shortVersionString>1.2.3</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
             <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.3
 
 - Rebuilds the audio engine when an output device renegotiates its sample rate, keeping filters and spectrum bins correctly tuned.
 - Stops DSP processing after prolonged digital silence, clears stale filter and limiter history before sleeping, and resumes on the first non-silent buffer.
+- Fixes silence-gate wake detection for padded or strided Core Audio buffer layouts so playback cannot remain muted after resuming.
 - Memoizes automatic preamp calculations by band values and active sample rate.
 - Eliminates periodic hidden-window layout spikes from unchanged permission-watchdog publications.
 - Remembers independent working EQ state for each output device without writing on every drag frame.
 - Removes the global mouse monitor that could race status-icon clicks while preserving the rounded, arrowless panel.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.3/OnlyEQ.app.zip" length="2474272" type="application/octet-stream" sparkle:edSignature="mpu+GW6ti7Tv6cg4Q4YNdITXnAm8ba2NrHeY22A6E7CVE6VRLTy9dRXdt/WaSjhz7QNukCpKzWHmwqCmqjm3Dw=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.3/OnlyEQ.app.zip" length="2473985" type="application/octet-stream" sparkle:edSignature="qjHeGD46c2DcZntWiw09NiKqct8AWaBtr1Sk1FQT1q+h04fw2fAXtuL5hiUjonipr7nnHudX7vCZrLv8K4RaDw=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.2.3.md
+++ b/release-notes/1.2.3.md
@@ -2,6 +2,7 @@
 
 - Rebuilds the audio engine when an output device renegotiates its sample rate, keeping filters and spectrum bins correctly tuned.
 - Stops DSP processing after prolonged digital silence, clears stale filter and limiter history before sleeping, and resumes on the first non-silent buffer.
+- Fixes silence-gate wake detection for padded or strided Core Audio buffer layouts so playback cannot remain muted after resuming.
 - Memoizes automatic preamp calculations by band values and active sample rate.
 - Eliminates periodic hidden-window layout spikes from unchanged permission-watchdog publications.
 - Remembers independent working EQ state for each output device without writing on every drag frame.


### PR DESCRIPTION
## Summary

Fixes a build-16 regression that could leave system audio muted after playback resumed from digital silence.

## Root cause

The silence gate scanned each raw Core Audio buffer as one contiguous vDSP vector. On the live AirPods buffer layout, that detector remained at zero even while playback was active, so the engine kept clearing its output.

## Fix

- Search the exact channel frames and strides already validated by the renderer.
- Keep the low-CPU one-second silence gate and realtime-state reset.
- Publish the hotfix as 1.2.3 build 17 so build-16 clients update automatically.

## Validation

- Reproduced build 16 remaining at gated CPU while a known sound played.
- Final build 17 left the gated path throughout the same repeated playback test.
- `swift build -Xswiftc -warnings-as-errors`
- `swift run OnlyEQ --test` — 78 passed, 0 failed
- Universal arm64/x86_64 build and deep signature verification
- Signed archive SHA-256: `89e74b4c3b94b82e4c3ffebc180f68cb1679c998a17e64a4e31129e5adc0eca1`
