### PR TITLE
Fix volume feedback loop and slider jitter with hardware devices

### DIFF
--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -50,7 +50,14 @@ final class AppState: ObservableObject {
 
     /// Volume as 0…maxBoost percent. ≤100 uses hardware volume when available;
     /// the portion above 100 % (or everything, for HDMI-style outputs) is software gain.
-    @Published var volumePercent: Double = 100 { didSet { applyVolume() } }
+    ///
+    /// Read-only from outside. Hardware observations write this directly, which
+    /// updates the UI and software gain but never touches the device. User intent
+    /// goes through `userVolumePercent` — the only path that pushes a value back
+    /// to the hardware. Keeping the hardware write out of `didSet` makes a
+    /// read→write feedback loop impossible by construction, not suppressed by a
+    /// guard: an observed value simply has no route back to a device write.
+    @Published private(set) var volumePercent: Double = 100 { didSet { applySoftwareGain() } }
     @Published var maxBoostPercent: Double = UserDefaults.standard.object(forKey: "maxBoost") as? Double ?? 200 {
         didSet { UserDefaults.standard.set(maxBoostPercent, forKey: "maxBoost") }
     }
@@ -158,7 +165,10 @@ final class AppState: ObservableObject {
             engine.start(excludedBundleIDs: excludedBundleIDs)
             engine.setIOBufferFrames(bufferFrames)
             pushToProcessor()
-            applyVolume()
+            // Push software gain only; refreshDevices() below re-syncs the true
+            // hardware volume from the device, so a rebuild never stomps a level
+            // the user changed while the engine was down.
+            applySoftwareGain()
         } else {
             engine.stop()
         }
@@ -474,16 +484,33 @@ final class AppState: ObservableObject {
         currentDeviceHasHardwareVolume
     }
 
-    private func applyVolume() {
-        guard !Self.screenshotMode, let device = currentDevice else { return }
-        if hasHardwareVolume {
-            hardwareVolumeWriter.submit(deviceID: device.id,
-                                        volume: Float(min(volumePercent, 100) / 100))
+    /// User-intent volume: the slider and other explicit controls bind here.
+    /// Setting it updates `volumePercent` (UI + software gain) and pushes the
+    /// value to the hardware. Reads never flow through here, so a hardware
+    /// observation can never loop back into a hardware write — the write-back
+    /// feedback loop (devices quantize to their own steps, so an echoed value
+    /// rarely round-trips exactly and would retrigger endlessly) is structurally
+    /// impossible.
+    var userVolumePercent: Double {
+        get { volumePercent }
+        set {
+            volumePercent = newValue
+            pushHardwareVolume(newValue)
         }
+    }
+
+    private func applySoftwareGain() {
+        guard !Self.screenshotMode else { return }
         let outputGainDB = softwareGainDB
         if !outputGainDB.isApproximatelyEqual(to: lastPushedSoftwareGainDB) {
             pushToProcessor()
         }
+    }
+
+    private func pushHardwareVolume(_ percent: Double) {
+        guard !Self.screenshotMode, hasHardwareVolume, let device = currentDevice else { return }
+        hardwareVolumeWriter.submit(deviceID: device.id,
+                                    volume: Float(min(percent, 100) / 100))
     }
 
     private func syncVolumeFromDevice(externalChange: Bool = false) {
@@ -498,7 +525,9 @@ final class AppState: ObservableObject {
         currentDeviceHasHardwareVolume = true
         // Preserve intentional software boost during routine refreshes. A real
         // hardware-volume event is an explicit user adjustment, so reflect it
-        // even when the UI was previously above 100%.
+        // even when the UI was previously above 100%. Assigning `volumePercent`
+        // directly marks this as an observation: it updates the UI and software
+        // gain but is never echoed back to the device.
         if externalChange || volumePercent <= 100 {
             let percent = Double(hw) * 100
             if abs(percent - volumePercent) > 0.5 {

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -124,6 +124,7 @@ final class AppState: ObservableObject {
     private var suggestedDeviceUIDs = Set(UserDefaults.standard.stringArray(forKey: "profileSuggestion.seenDeviceUIDs") ?? [])
     private var currentDeviceHasHardwareVolume = false
     private var lastPushedSoftwareGainDB = Double.nan
+    private var pendingExternalVolumeSync: DispatchWorkItem?
     private struct HardwareVolumeListener {
         let deviceID: AudioObjectID
         let address: AudioObjectPropertyAddress
@@ -329,7 +330,7 @@ final class AppState: ObservableObject {
             let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
                 Task { @MainActor in
                     guard let self, self.currentDevice?.id == deviceID else { return }
-                    self.syncVolumeFromDevice(externalChange: true)
+                    self.scheduleExternalVolumeSync()
                 }
             }
             if AudioObjectAddPropertyListenerBlock(deviceID, &address, .main, block) == noErr {
@@ -511,6 +512,28 @@ final class AppState: ObservableObject {
         guard !Self.screenshotMode, hasHardwareVolume, let device = currentDevice else { return }
         hardwareVolumeWriter.submit(deviceID: device.id,
                                     volume: Float(min(percent, 100) / 100))
+    }
+
+    /// A hardware volume-key press makes coreaudiod ramp the level and fire a
+    /// burst of change notifications — and it briefly overshoots the target by a
+    /// step before settling (e.g. 30 → 31 → 30). The overshoot is always the
+    /// *first* value reported, so publishing on the leading edge draws it as a
+    /// visible knob stutter.
+    ///
+    /// Trailing-edge throttle: the first change schedules a single read a short
+    /// window later; further notifications in that window are folded in, so we
+    /// read the *settled* value once per window rather than the overshoot. It
+    /// throttles rather than debounces (the timer is never reset), so a held key
+    /// that sweeps the volume keeps updating steadily instead of freezing until
+    /// release.
+    private func scheduleExternalVolumeSync() {
+        guard pendingExternalVolumeSync == nil else { return }
+        let work = DispatchWorkItem { [weak self] in
+            self?.pendingExternalVolumeSync = nil
+            self?.syncVolumeFromDevice(externalChange: true)
+        }
+        pendingExternalVolumeSync = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
     }
 
     private func syncVolumeFromDevice(externalChange: Bool = false) {

--- a/Sources/OnlyEQ/App/ScreenshotRenderer.swift
+++ b/Sources/OnlyEQ/App/ScreenshotRenderer.swift
@@ -20,7 +20,7 @@ enum ScreenshotRenderer {
             demo.source = "AutoEq"
             state.preset = demo
         }
-        state.volumePercent = 65
+        state.userVolumePercent = 65
 
         let dir = URL(fileURLWithPath: outputDir)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)

--- a/Sources/OnlyEQ/UI/PopoverView.swift
+++ b/Sources/OnlyEQ/UI/PopoverView.swift
@@ -104,7 +104,7 @@ struct PopoverView: View {
                     .fixedSize()
                     Spacer(minLength: 0)
                 }
-                BoostSlider(value: $state.volumePercent, maxPercent: state.maxBoostPercent)
+                BoostSlider(value: $state.userVolumePercent, maxPercent: state.maxBoostPercent)
             }
         }
     }

--- a/Sources/OnlyEQ/UI/SettingsView.swift
+++ b/Sources/OnlyEQ/UI/SettingsView.swift
@@ -302,6 +302,6 @@ struct AdvancedSettings: View {
         }
         for preset in state.store.customPresets { state.store.delete(preset) }
         state.applyFlat()
-        state.volumePercent = 100
+        state.userVolumePercent = 100
     }
 }


### PR DESCRIPTION
## Bug

With the popover open, pressing Volume Down (or Up) on a device with hardware
volume control (e.g. built-in speakers) sends the volume into a runaway
oscillation: it slides down smoothly and gets visibly "stuck" around a
particular percentage, both on the device and in the app's own slider.

Captured from `~/Library/Logs/OnlyEQ.log` after a single Volume Down press:

```
17:25:00 volume: external 27.0%
17:25:00 volume: external 26.0%
17:25:00 volume: external 25.0%
17:25:00 volume: external 30.0%
17:25:00 volume: external 29.0%
... (repeats ~1200 times over ~2 minutes, oscillating between 25% and 31%)
```

## Root cause

`syncVolumeFromDevice(externalChange:)` mirrors a hardware volume change into
`volumePercent`, but `volumePercent`'s `didSet` unconditionally called
`applyVolume()`, which wrote that value straight back to the hardware.

Devices quantize volume to their own internal steps (often non-linearly spaced,
~6-9% apart per step), so a write rarely round-trips to exactly the value just
read. The mismatch fires another hardware-volume notification, which gets synced
and written back again — forever, bouncing between two nearby steps.

## Fix (commit 1)

Split the two meanings of a volume change apart:

- `volumePercent` is now `private(set)` and its `didSet` only updates software
  gain, never the hardware. Hardware observations assign it directly, so they
  update the UI/software gain but can never echo back to the device.
- User intent goes through a new `userVolumePercent` — the only path that writes
  hardware — which the slider and reset bind to.

The loop is now impossible by construction rather than suppressed by a flag. As
a side effect, `rebuildEngine` now pushes only software gain and lets
`refreshDevices` re-sync the real hardware level, so a rebuild no longer stomps a
volume changed while the engine was down.

## Slider jitter (commit 2)

While verifying the fix, a separate pre-existing issue surfaced: a volume-key
press makes coreaudiod ramp the level and briefly **overshoot** the target by one
step before settling (e.g. `30 → 31 → 30`). Syncing on every notification drew
that overshoot as a visible knob stutter:

```
volume: external 31.0%
volume: external 30.0%   ← overshoot corrected, on every step
volume: external 37.0%
volume: external 36.0%
```

Commit 2 routes the hardware-volume listener through a trailing-edge throttle:
the settled value is read once per short window instead of the overshoot, and it
throttles rather than debounces so a held key still tracks live instead of
freezing until release.

## Testing

- Existing self-tests pass: `swift run OnlyEQ --test` → 84/84.
- Manually verified on built-in speakers: single presses and held sweeps (0→100)
  now settle cleanly with no oscillation and no knob stutter; the slider drag and
  >100% software boost still work.