### PR TITLE
Fix tap routing for multistream outputs

### DIFF
--- a/Sources/OnlyEQ/Audio/AudioDeviceManager.swift
+++ b/Sources/OnlyEQ/Audio/AudioDeviceManager.swift
@@ -126,6 +126,42 @@ enum AudioDeviceManager {
         return value
     }
 
+    static func tapFormat(_ id: AudioObjectID) -> AudioStreamBasicDescription? {
+        var addr = address(kAudioTapPropertyFormat)
+        var value = AudioStreamBasicDescription()
+        var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        guard AudioObjectGetPropertyData(id, &addr, 0, nil, &size, &value) == noErr else { return nil }
+        return value
+    }
+
+    static func inputStreamFormats(_ id: AudioObjectID) -> [AudioStreamBasicDescription]? {
+        var streamAddress = address(kAudioDevicePropertyStreams, scope: kAudioDevicePropertyScopeInput)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(id, &streamAddress, 0, nil, &size) == noErr else { return nil }
+        var streams = [AudioObjectID](repeating: 0, count: Int(size) / MemoryLayout<AudioObjectID>.size)
+        guard AudioObjectGetPropertyData(id, &streamAddress, 0, nil, &size, &streams) == noErr else { return nil }
+        var formats: [AudioStreamBasicDescription] = []
+        formats.reserveCapacity(streams.count)
+        for stream in streams {
+            var formatAddress = address(kAudioStreamPropertyVirtualFormat)
+            var format = AudioStreamBasicDescription()
+            var formatSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+            guard AudioObjectGetPropertyData(stream, &formatAddress, 0, nil, &formatSize, &format) == noErr else { return nil }
+            formats.append(format)
+        }
+        return formats
+    }
+
+    static func inputStreamChannelCounts(_ id: AudioObjectID) -> [UInt32]? {
+        var addr = address(kAudioDevicePropertyStreamConfiguration, scope: kAudioDevicePropertyScopeInput)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(id, &addr, 0, nil, &size) == noErr, size > 0 else { return nil }
+        let storage = UnsafeMutableRawPointer.allocate(byteCount: Int(size), alignment: MemoryLayout<AudioBufferList>.alignment)
+        defer { storage.deallocate() }
+        guard AudioObjectGetPropertyData(id, &addr, 0, nil, &size, storage) == noErr else { return nil }
+        return UnsafeMutableAudioBufferListPointer(storage.assumingMemoryBound(to: AudioBufferList.self)).map(\.mNumberChannels)
+    }
+
     // MARK: - Volume
 
     static func hardwareVolumeAddresses(_ id: AudioObjectID) -> [AudioObjectPropertyAddress] {

--- a/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
+++ b/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
@@ -3,6 +3,41 @@ import CoreAudio
 import AudioToolbox
 import Accelerate
 
+struct TapInputSelection: Equatable {
+    let bufferIndex: Int
+    let channels: Int
+
+    init(bufferIndex: Int, channels: Int) {
+        self.bufferIndex = bufferIndex
+        self.channels = channels
+    }
+
+    static func select(tapFormat: AudioStreamBasicDescription,
+                       aggregateInputFormats: [AudioStreamBasicDescription],
+                       aggregateInputChannels: [UInt32]) -> TapInputSelection? {
+        guard tapFormat.mFormatID == kAudioFormatLinearPCM,
+              tapFormat.mFormatFlags & kAudioFormatFlagIsFloat != 0,
+              tapFormat.mFormatFlags & kAudioFormatFlagIsNonInterleaved == 0,
+              tapFormat.mBitsPerChannel == 32,
+              tapFormat.mChannelsPerFrame == 2,
+              aggregateInputFormats.count == aggregateInputChannels.count else { return nil }
+        var matches: [TapInputSelection] = []
+        for (index, format) in aggregateInputFormats.enumerated()
+            where aggregateInputChannels[index] == 2 && compatible(format, tapFormat) {
+            matches.append(TapInputSelection(bufferIndex: index, channels: 2))
+        }
+        guard matches.count == 1 else { return nil }
+        return matches[0]
+    }
+
+    private static func compatible(_ lhs: AudioStreamBasicDescription, _ rhs: AudioStreamBasicDescription) -> Bool {
+        lhs.mSampleRate == rhs.mSampleRate && lhs.mFormatID == rhs.mFormatID && lhs.mFormatFlags == rhs.mFormatFlags
+            && lhs.mBytesPerPacket == rhs.mBytesPerPacket && lhs.mFramesPerPacket == rhs.mFramesPerPacket
+            && lhs.mBytesPerFrame == rhs.mBytesPerFrame && lhs.mChannelsPerFrame == rhs.mChannelsPerFrame
+            && lhs.mBitsPerChannel == rhs.mBitsPerChannel
+    }
+}
+
 /// System-wide EQ engine built on Core Audio process taps (macOS 14.4+).
 ///
 /// Signal path: muted global tap (silences original output) → aggregate device
@@ -46,6 +81,7 @@ final class ProcessTapEngine {
     /// Consecutive all-zero input frames, saturated at one second's worth.
     private var silentFrames = 0
     private var isSilenceGated = false
+    private var preparedInput: TapInputSelection
 
     var onStateChange: ((State) -> Void)?
 
@@ -54,10 +90,12 @@ final class ProcessTapEngine {
     /// the owner must restart the engine to stay on pitch.
     var onSampleRateChange: (() -> Void)?
 
-    init() {
+    init(preparedInput: TapInputSelection = TapInputSelection(bufferIndex: 0, channels: 2)) {
+        self.preparedInput = preparedInput
         inputChannels.reserveCapacity(8)
         activeChannels.reserveCapacity(8)
         channelScratch.reserveCapacity(8)
+        prepareScratch(channels: preparedInput.channels, frames: ioBufferFrames)
     }
 
     // MARK: - Lifecycle
@@ -133,6 +171,21 @@ final class ProcessTapEngine {
         }
         aggregateID = newAggregateID
 
+        // AudioHardware process taps do not prove provenance by stream order:
+        // adjacent mono buffers could be physical input, so only one uniquely
+        // matched interleaved stereo tap stream is accepted.
+        guard let tapFormat = AudioDeviceManager.tapFormat(tapID),
+              let inputFormats = AudioDeviceManager.inputStreamFormats(aggregateID),
+              let inputChannels = AudioDeviceManager.inputStreamChannelCounts(aggregateID),
+              let selection = TapInputSelection.select(tapFormat: tapFormat,
+                                                        aggregateInputFormats: inputFormats,
+                                                        aggregateInputChannels: inputChannels) else {
+            cleanup()
+            transition(to: .failed("Unsupported aggregate input topology: no unique tap stream."))
+            return
+        }
+        preparedInput = selection
+
         // 3. IOProc: tapped audio arrives as input, processed audio leaves as output.
         hasReceivedAudio = false
         silentFrames = 0
@@ -164,11 +217,6 @@ final class ProcessTapEngine {
 
     func stop() {
         removeSampleRateListener()
-        if let ioProcID, aggregateID != 0 {
-            AudioDeviceStop(aggregateID, ioProcID)
-            AudioDeviceDestroyIOProcID(aggregateID, ioProcID)
-        }
-        ioProcID = nil
         cleanup()
         if state != .stopped { transition(to: .stopped) }
     }
@@ -179,6 +227,11 @@ final class ProcessTapEngine {
     }
 
     private func cleanup() {
+        if let ioProcID, aggregateID != 0 {
+            AudioDeviceStop(aggregateID, ioProcID)
+            AudioDeviceDestroyIOProcID(aggregateID, ioProcID)
+        }
+        ioProcID = nil
         if aggregateID != 0 {
             AudioHardwareDestroyAggregateDevice(aggregateID)
             aggregateID = 0
@@ -257,23 +310,31 @@ final class ProcessTapEngine {
     func render(input: UnsafePointer<AudioBufferList>, output: UnsafeMutablePointer<AudioBufferList>) {
         let inputList = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: input))
         let outputList = UnsafeMutableAudioBufferListPointer(output)
-        guard inputList.count > 0, outputList.count > 0 else { return }
-
-        // Gather input channel pointers (tap side). The tap delivers Float32;
-        // buffers may be interleaved-stereo-in-one or split per channel.
-        inputChannels.removeAll(keepingCapacity: true)
-        var frameCount = Int.max
-        for buffer in inputList {
-            guard let data = buffer.mData else { continue }
-            let channelCount = max(Int(buffer.mNumberChannels), 1)
-            let frames = Int(buffer.mDataByteSize) / MemoryLayout<Float>.size / channelCount
-            let floatPtr = data.assumingMemoryBound(to: Float.self)
-            frameCount = min(frameCount, frames)
-            for ch in 0..<channelCount {
-                inputChannels.append(InputChannel(pointer: floatPtr + ch, stride: channelCount))
-            }
+        guard inputList.count > 0, outputList.count > 0 else {
+            zero(outputList)
+            return
         }
-        guard !inputChannels.isEmpty, frameCount != .max, frameCount > 0 else { return }
+        // Consume only the prepared tap stream; other aggregate inputs can be
+        // physical streams and must never influence output.
+        inputChannels.removeAll(keepingCapacity: true)
+        guard preparedInput.bufferIndex < inputList.count else { zero(outputList); return }
+        let selectedBuffer = inputList[preparedInput.bufferIndex]
+        let channels = preparedInput.channels
+        guard channels == 2, let data = selectedBuffer.mData, Int(selectedBuffer.mNumberChannels) == channels,
+              selectedBuffer.mDataByteSize % UInt32(MemoryLayout<Float>.size * channels) == 0 else { zero(outputList); return }
+        let frameCount = Int(selectedBuffer.mDataByteSize) / MemoryLayout<Float>.size / channels
+        guard frameCount > 0 else {
+            zero(outputList)
+            return
+        }
+        let floatPtr = data.assumingMemoryBound(to: Float.self)
+        for ch in 0..<channels {
+            inputChannels.append(InputChannel(pointer: floatPtr + ch, stride: channels))
+        }
+        guard inputChannels.count <= channelScratch.count, frameCount <= scratchCapacity else {
+            zero(outputList)
+            return
+        }
 
         // Inspect the exact frames/channels the renderer consumes. Scanning the
         // raw AudioBuffer storage as one contiguous vDSP vector is incorrect for
@@ -298,17 +359,12 @@ final class ProcessTapEngine {
                     processor.resetRenderState()
                     isSilenceGated = true
                 }
-                for buffer in outputList {
-                    guard let data = buffer.mData else { continue }
-                    vDSP_vclr(data.assumingMemoryBound(to: Float.self), 1,
-                              vDSP_Length(Int(buffer.mDataByteSize) / MemoryLayout<Float>.size))
-                }
+                zero(outputList)
                 return
             }
         }
 
         // De-interleave into scratch, process, then write to the output buffers.
-        prepareScratch(channels: inputChannels.count, frames: frameCount)
         activeChannels.removeAll(keepingCapacity: true)
         var zero: Float = 0
         for (index, channel) in inputChannels.enumerated() {
@@ -360,4 +416,12 @@ final class ProcessTapEngine {
     }
 
     private var scratchCapacity = 0
+
+    private func zero(_ outputList: UnsafeMutableAudioBufferListPointer) {
+        for buffer in outputList {
+            guard let data = buffer.mData else { continue }
+            vDSP_vclr(data.assumingMemoryBound(to: Float.self), 1,
+                      vDSP_Length(Int(buffer.mDataByteSize) / MemoryLayout<Float>.size))
+        }
+    }
 }

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -259,8 +259,164 @@ enum TestRunner {
         }
     }
 
+    private static func withAudioBufferList(_ buffers: [AudioBuffer], _ body: (UnsafeMutablePointer<AudioBufferList>) -> Void) {
+        let offset = MemoryLayout<AudioBufferList>.offset(of: \.mBuffers)!
+        let storage = UnsafeMutableRawPointer.allocate(byteCount: offset + buffers.count * MemoryLayout<AudioBuffer>.size,
+                                                        alignment: MemoryLayout<AudioBufferList>.alignment)
+        defer { storage.deallocate() }
+        let list = storage.assumingMemoryBound(to: AudioBufferList.self)
+        list.pointee.mNumberBuffers = UInt32(buffers.count)
+        let destination = storage.advanced(by: offset).assumingMemoryBound(to: AudioBuffer.self)
+        destination.initialize(from: buffers, count: buffers.count)
+        body(list)
+    }
+
     private static func engineRenderTests() {
         let frames = 512, channels = 2
+
+        let stereo = AudioStreamBasicDescription(mSampleRate: 48_000, mFormatID: kAudioFormatLinearPCM,
+                                                  mFormatFlags: kAudioFormatFlagIsFloat, mBytesPerPacket: 8,
+                                                  mFramesPerPacket: 1, mBytesPerFrame: 8, mChannelsPerFrame: 2,
+                                                  mBitsPerChannel: 32, mReserved: 0)
+        var physical = stereo
+        physical.mChannelsPerFrame = 4
+        physical.mBytesPerPacket = 16
+        physical.mBytesPerFrame = 16
+        var mono = stereo
+        mono.mChannelsPerFrame = 1
+        mono.mBytesPerPacket = 4
+        mono.mBytesPerFrame = 4
+        var nonInterleaved = stereo
+        nonInterleaved.mFormatFlags |= kAudioFormatFlagIsNonInterleaved
+        expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [physical, stereo], aggregateInputChannels: [4, 2]) == TapInputSelection(bufferIndex: 1, channels: 2), "tap selection finds trailing stereo stream")
+        expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [stereo, physical], aggregateInputChannels: [2, 4]) == TapInputSelection(bufferIndex: 0, channels: 2), "tap selection follows queried stream order")
+        expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [stereo], aggregateInputChannels: [2]) == TapInputSelection(bufferIndex: 0, channels: 2), "tap selection supports built-in stereo")
+        expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [physical, mono, mono], aggregateInputChannels: [4, 1, 1]) == nil, "tap selection rejects adjacent mono candidates")
+        expect(TapInputSelection.select(tapFormat: nonInterleaved, aggregateInputFormats: [nonInterleaved], aggregateInputChannels: [2]) == nil, "tap selection rejects non-interleaved tap format")
+        expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [physical], aggregateInputChannels: [4]) == nil, "tap selection rejects missing stereo stream")
+        expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [stereo, stereo], aggregateInputChannels: [2, 2]) == nil, "tap selection rejects ambiguous stereo streams")
+
+        let reversedEngine = ProcessTapEngine(preparedInput: TapInputSelection(bufferIndex: 0, channels: 2))
+        var reversedTapInput = (0..<frames).flatMap { _ in [Float(0.125), Float(-0.25)] }
+        var reversedPhysicalInput = [Float](repeating: 77, count: frames * 4)
+        var reversedOutput = [Float](repeating: 0, count: frames * 4)
+        reversedTapInput.withUnsafeMutableBufferPointer { tapBuffer in
+            reversedPhysicalInput.withUnsafeMutableBufferPointer { physicalBuffer in
+                reversedOutput.withUnsafeMutableBufferPointer { outputBuffer in
+                    withAudioBufferList([
+                        AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(tapBuffer.count * MemoryLayout<Float>.size), mData: tapBuffer.baseAddress),
+                        AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(physicalBuffer.count * MemoryLayout<Float>.size), mData: physicalBuffer.baseAddress),
+                    ]) { input in
+                        withAudioBufferList([
+                            AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(outputBuffer.count * MemoryLayout<Float>.size), mData: outputBuffer.baseAddress),
+                        ]) { output in
+                            reversedEngine.render(input: input, output: output)
+                        }
+                    }
+                }
+            }
+        }
+        expect((0..<frames).allSatisfy { frame in
+            let base = frame * 4
+            return reversedOutput[base] == 0.125 && reversedOutput[base + 1] == -0.25
+                && reversedOutput[base + 2] == 0.125 && reversedOutput[base + 3] == -0.25
+        }, "render consumes selected tap at index 0 before physical stream")
+        expect(!reversedOutput.contains(77), "reversed render never outputs physical sentinel")
+
+        let routingEngine = ProcessTapEngine(preparedInput: TapInputSelection(bufferIndex: 1, channels: 2))
+        var physicalInput = [Float](repeating: 99, count: frames * 4)
+        var tapInput = (0..<frames).flatMap { _ in [Float(0.25), Float(-0.5)] }
+        var fourChannelOutput = [Float](repeating: 0, count: frames * 4)
+        physicalInput.withUnsafeMutableBufferPointer { physicalBuffer in
+            tapInput.withUnsafeMutableBufferPointer { tapBuffer in
+                fourChannelOutput.withUnsafeMutableBufferPointer { outputBuffer in
+                    withAudioBufferList([
+                        AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(physicalBuffer.count * MemoryLayout<Float>.size), mData: physicalBuffer.baseAddress),
+                        AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(tapBuffer.count * MemoryLayout<Float>.size), mData: tapBuffer.baseAddress),
+                    ]) { input in
+                        withAudioBufferList([
+                            AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(outputBuffer.count * MemoryLayout<Float>.size), mData: outputBuffer.baseAddress),
+                        ]) { output in
+                            routingEngine.render(input: input, output: output)
+                        }
+                    }
+                }
+            }
+        }
+        expect((0..<frames).allSatisfy { frame in
+            let base = frame * 4
+            return fourChannelOutput[base] == 0.25 && fourChannelOutput[base + 1] == -0.5
+                && fourChannelOutput[base + 2] == 0.25 && fourChannelOutput[base + 3] == -0.5
+        }, "render routes only selected tap stereo as L/R/L/R")
+        expect(!fourChannelOutput.contains(99), "iD4 render never outputs physical sentinel")
+
+        var disabledOutput = [Float](repeating: 0, count: frames * 4)
+        tapInput.withUnsafeMutableBufferPointer { tapBuffer in
+            disabledOutput.withUnsafeMutableBufferPointer { outputBuffer in
+                withAudioBufferList([
+                    AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(frames * 4 * MemoryLayout<Float>.size), mData: nil),
+                    AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(tapBuffer.count * MemoryLayout<Float>.size), mData: tapBuffer.baseAddress),
+                ]) { input in
+                    withAudioBufferList([
+                        AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(outputBuffer.count * MemoryLayout<Float>.size), mData: outputBuffer.baseAddress),
+                    ]) { output in
+                        routingEngine.render(input: input, output: output)
+                    }
+                }
+            }
+        }
+        expect(disabledOutput == fourChannelOutput, "disabled physical input with null data does not affect selected tap")
+
+        let mismatchEngine = ProcessTapEngine(preparedInput: TapInputSelection(bufferIndex: 1, channels: 2))
+        var mismatchOutput = [Float](repeating: 1, count: frames * 4)
+        tapInput.withUnsafeMutableBufferPointer { tapBuffer in
+            mismatchOutput.withUnsafeMutableBufferPointer { outputBuffer in
+                withAudioBufferList([
+                    AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(frames * 4 * MemoryLayout<Float>.size), mData: nil),
+                    AudioBuffer(mNumberChannels: 1, mDataByteSize: UInt32(tapBuffer.count * MemoryLayout<Float>.size / 2), mData: tapBuffer.baseAddress),
+                ]) { input in
+                    withAudioBufferList([
+                        AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(outputBuffer.count * MemoryLayout<Float>.size), mData: outputBuffer.baseAddress),
+                    ]) { output in
+                        mismatchEngine.render(input: input, output: output)
+                    }
+                }
+            }
+        }
+        expect(mismatchOutput.allSatisfy { $0 == 0 }, "selected-buffer shape mismatch zeros output")
+
+        let nullEngine = ProcessTapEngine(preparedInput: TapInputSelection(bufferIndex: 1, channels: 2))
+        var nullOutput = [Float](repeating: 1, count: frames * 2)
+        nullOutput.withUnsafeMutableBufferPointer { outputBuffer in
+            withAudioBufferList([
+                AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(frames * 4 * MemoryLayout<Float>.size), mData: nil),
+                AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(frames * 2 * MemoryLayout<Float>.size), mData: nil),
+            ]) { input in
+                withAudioBufferList([
+                    AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(outputBuffer.count * MemoryLayout<Float>.size), mData: outputBuffer.baseAddress),
+                ]) { output in
+                    nullEngine.render(input: input, output: output)
+                }
+            }
+        }
+        expect(nullOutput.allSatisfy { $0 == 0 }, "null selected tap buffer zeros output")
+
+        let missingEngine = ProcessTapEngine(preparedInput: TapInputSelection(bufferIndex: 2, channels: 2))
+        var missingOutput = [Float](repeating: 1, count: frames * 2)
+        tapInput.withUnsafeMutableBufferPointer { tapBuffer in
+            missingOutput.withUnsafeMutableBufferPointer { outputBuffer in
+                withAudioBufferList([
+                    AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(tapBuffer.count * MemoryLayout<Float>.size), mData: tapBuffer.baseAddress),
+                ]) { input in
+                    withAudioBufferList([
+                        AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(outputBuffer.count * MemoryLayout<Float>.size), mData: outputBuffer.baseAddress),
+                    ]) { output in
+                        missingEngine.render(input: input, output: output)
+                    }
+                }
+            }
+        }
+        expect(missingOutput.allSatisfy { $0 == 0 }, "missing selected tap buffer zeros output")
 
         // Audio starting later in the buffer must still mark the tap as live.
         let lateEngine = ProcessTapEngine()


### PR DESCRIPTION
## TLDR
I encountered a problem using OnlyEQ on a specific hardware, tried to set GPT5.6 to fix it. Performed various practical tests in a few iterations. Managed to produce a new build that works for my usecase with the solutions described below.

- The code was entirely LLM generated and managed; i have no prior Swift or domain knowledge. (Gave only common sense directions)
- I do not assume by default this is merge ready or worth the repo owners time, but the problem was real and maybe the solution found is useful.
- If there was another, better, way to surface this information for anyone facing the same problem, let me know. As of now my objective was to leave enough pointers for producing a similar fix to whom needs them.
- If the fix looks interesting and more practical testing is needed when integrating it into a new release, I will gladly contribute using the same physical setup for verification.

[all text below was LLM generated]

## Summary

OnlyEQ could mute external audio interfaces that expose physical input streams alongside the global process tap. The renderer flattened every aggregate input buffer and rendered the first channels, which could select silent hardware inputs instead of the tapped system mix.

This change identifies the unique aggregate input stream matching the stereo process tap during setup and renders only that buffer.

## Problem

On an Audient iD4 MKII:

- enabling OnlyEQ produced silence;
- disabling it restored audio immediately;
- the aggregate IOProc supplied a four-channel physical input buffer followed by the two-channel process-tap buffer;
- the renderer processed all six channels but wrote only the first four to the four-channel output.

The result was valid callbacks and nonzero tapped audio, but silent physical-input channels occupied every rendered output channel.

## Changes

- Query aggregate input stream topology before starting the device.
- Select the tap stream only when exactly one interleaved input stream matches the known stereo tap format.
- Render and inspect only the selected tap buffer.
- Clear output safely if the selected buffer disappears or changes shape.
- Preserve cleanup that destroys the IOProc and muted tap on startup failure.
- Add focused multibuffer routing regression checks.

## Non-goals

- General multichannel layout mapping.
- PCM format conversion.
- Device-specific Audient behavior.
- Permanent engine telemetry or probe redesign.
- Assuming that the tap is always the final input buffer.

## Verification

Automated:

- `swift run OnlyEQ --test` — 99 passed, 0 failed.
- `swift build` — passed.
- `./scripts/build-app.sh` — passed.
- `git diff --check` — passed.

Hardware:

- Audient iD4 output remains audible and EQ changes are audible.
- MacBook Pro Speakers remain audible and filtered.
- iD4 → built-in → iD4 route switching succeeds without restarting or toggling OnlyEQ.

Final isolated Scope A hardware regression passed for all three checks.

## Risk and fallback

- Devices with no unique tap-format match are rejected rather than guessed.
- Non-interleaved/adjacent-mono topology is rejected because buffer adjacency does not prove tap provenance.
- Existing L/R/L/R output cycling is retained for four-channel outputs.

## Expected files

- `Sources/OnlyEQ/Audio/AudioDeviceManager.swift`
- `Sources/OnlyEQ/Audio/ProcessTapEngine.swift`
- `Sources/OnlyEQ/TestRunner.swift`

No investigation logs, diagnostic target, probe file protocol, or machine-specific documentation should be included.