### PR TITLE
Release OnlyEQ 1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ git clone https://github.com/zollans/OnlyEQ && cd OnlyEQ
 
 Requires macOS 14.4 or newer. On first launch it asks for System Audio Recording permission — that's the tap. macOS shows the purple recording indicator while EQ is active; audio never leaves your machine.
 
-Starting with 1.1.0, OnlyEQ checks for signed updates automatically and installs them in the background. Right-click the menu-bar icon and choose **Check for Updates…** to check immediately. Versions 1.0.x need one final manual install of 1.1.0 before automatic updates are available.
+OnlyEQ checks for signed updates automatically and installs them in the background. Because the update-signing key changed, versions through 1.2.3 require one manual installation of 1.2.4. Automatic updates resume normally after 1.2.4 is installed. Right-click the menu-bar icon and choose **Check for Updates…** to check immediately.
 
 ## What it does
 
@@ -63,7 +63,7 @@ swift run OnlyEQ --profile-suggestion-probe # previews Bluetooth profile discove
 swift run OnlyEQ --menu-panel-probe    # previews the arrowless menu panel
 swift run OnlyEQ --screenshots out/   # renders the README screenshots
 ./scripts/build-app.sh release        # universal binary release build
-./scripts/prepare-release.sh 1.2.2    # signed archive + appcast
+./scripts/prepare-release.sh 1.2.4    # signed archive + v2 appcast
 ```
 
 Tests run inside the binary because the Command Line Tools don't ship XCTest. Diagnostics land in `~/Library/Logs/OnlyEQ.log`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,25 +1,27 @@
 # Releasing OnlyEQ
 
-OnlyEQ uses Sparkle 2 for signed automatic updates. The Ed25519 private key stays in the macOS login Keychain under the account `zollans.OnlyEQ`; never commit or upload an exported private key. The corresponding public key lives in `Resources/Info.plist`.
+OnlyEQ uses Sparkle 2 for signed automatic updates. Releases starting with 1.2.4 use the Ed25519 private key stored in the macOS login Keychain under the account `zollans.OnlyEQ.v2`; never commit or upload an exported private key. The corresponding public key lives in `Resources/Info.plist`.
+
+The original signing key used through 1.2.3 was lost. Version 1.2.4 is therefore a one-time manual bridge release: users on 1.2.3 or earlier must reinstall it manually. It uses the separate `appcast-v2.xml` feed so older clients are not offered an update they cannot verify. Once 1.2.4 is installed, later releases update automatically through the v2 feed.
 
 For each release:
 
 1. Increment both `CFBundleVersion` and `CFBundleShortVersionString` in `Resources/Info.plist`.
 2. Add `release-notes/VERSION.md`.
 3. Run `./scripts/prepare-release.sh VERSION`.
-4. Commit the source changes and generated `appcast.xml`, merge them to `main`, and tag the merged commit as `vVERSION`.
-5. Publish `build/OnlyEQ.app.zip` and `appcast.xml` as release assets, using the versioned release-notes file as the GitHub release notes.
+4. Commit the source changes and generated `appcast-v2.xml`, merge them to `main`, and tag the merged commit as `vVERSION`.
+5. Publish `build/OnlyEQ.app.zip` and `appcast-v2.xml` as release assets, using the versioned release-notes file as the GitHub release notes.
 
 Example publishing command after the release commit is on `main`:
 
 ```sh
-gh release create v1.1.0 \
-  build/OnlyEQ.app.zip appcast.xml \
-  --title "OnlyEQ 1.1.0" \
-  --notes-file release-notes/1.1.0.md \
+gh release create v1.2.4 \
+  build/OnlyEQ.app.zip appcast-v2.xml \
+  --title "OnlyEQ 1.2.4" \
+  --notes-file release-notes/1.2.4.md \
   --target main
 ```
 
-The appcast is served from `https://raw.githubusercontent.com/zollans/OnlyEQ/main/appcast.xml`. Update archives must retain the app bundle and Sparkle framework symlinks; `prepare-release.sh` uses `ditto` for that reason.
+The current appcast is served from `https://raw.githubusercontent.com/zollans/OnlyEQ/main/appcast-v2.xml`. Keep the legacy `appcast.xml` frozen at 1.2.3 for clients that still trust the lost key. Update archives must retain the app bundle and Sparkle framework symlinks; `prepare-release.sh` uses `ditto` for that reason.
 
 OnlyEQ is ad-hoc signed rather than Developer ID signed or notarized. Sparkle archive signatures authenticate updates, but losing the Ed25519 private key would require another manual bridge release because Developer ID key rotation is unavailable.

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.3</string>
+	<string>1.2.4</string>
 	<key>CFBundleExecutable</key>
 	<string>OnlyEQ</string>
 	<key>CFBundlePackageType</key>
@@ -27,9 +27,9 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>Free and open — no license required.</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.githubusercontent.com/zollans/OnlyEQ/main/appcast.xml</string>
+	<string>https://raw.githubusercontent.com/zollans/OnlyEQ/main/appcast-v2.xml</string>
 	<key>SUPublicEDKey</key>
-	<string>d1vSCptrf7SGcC7X14QhVcO47cVirp0YwFtQHrw8eao=</string>
+	<string>r5SvxI0Rl5w0dW4XgJIq/TuAq3m6bHPqpmIyp0aHh/o=</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUAutomaticallyUpdate</key>

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -50,7 +50,14 @@ final class AppState: ObservableObject {
 
     /// Volume as 0…maxBoost percent. ≤100 uses hardware volume when available;
     /// the portion above 100 % (or everything, for HDMI-style outputs) is software gain.
-    @Published var volumePercent: Double = 100 { didSet { applyVolume() } }
+    ///
+    /// Read-only from outside. Hardware observations write this directly, which
+    /// updates the UI and software gain but never touches the device. User intent
+    /// goes through `userVolumePercent` — the only path that pushes a value back
+    /// to the hardware. Keeping the hardware write out of `didSet` makes a
+    /// read→write feedback loop impossible by construction, not suppressed by a
+    /// guard: an observed value simply has no route back to a device write.
+    @Published private(set) var volumePercent: Double = 100 { didSet { applySoftwareGain() } }
     @Published var maxBoostPercent: Double = UserDefaults.standard.object(forKey: "maxBoost") as? Double ?? 200 {
         didSet { UserDefaults.standard.set(maxBoostPercent, forKey: "maxBoost") }
     }
@@ -158,7 +165,10 @@ final class AppState: ObservableObject {
             engine.start(excludedBundleIDs: excludedBundleIDs)
             engine.setIOBufferFrames(bufferFrames)
             pushToProcessor()
-            applyVolume()
+            // Push software gain only; refreshDevices() below re-syncs the true
+            // hardware volume from the device, so a rebuild never stomps a level
+            // the user changed while the engine was down.
+            applySoftwareGain()
         } else {
             engine.stop()
         }
@@ -474,16 +484,33 @@ final class AppState: ObservableObject {
         currentDeviceHasHardwareVolume
     }
 
-    private func applyVolume() {
-        guard !Self.screenshotMode, let device = currentDevice else { return }
-        if hasHardwareVolume {
-            hardwareVolumeWriter.submit(deviceID: device.id,
-                                        volume: Float(min(volumePercent, 100) / 100))
+    /// User-intent volume: the slider and other explicit controls bind here.
+    /// Setting it updates `volumePercent` (UI + software gain) and pushes the
+    /// value to the hardware. Reads never flow through here, so a hardware
+    /// observation can never loop back into a hardware write — the write-back
+    /// feedback loop (devices quantize to their own steps, so an echoed value
+    /// rarely round-trips exactly and would retrigger endlessly) is structurally
+    /// impossible.
+    var userVolumePercent: Double {
+        get { volumePercent }
+        set {
+            volumePercent = newValue
+            pushHardwareVolume(newValue)
         }
+    }
+
+    private func applySoftwareGain() {
+        guard !Self.screenshotMode else { return }
         let outputGainDB = softwareGainDB
         if !outputGainDB.isApproximatelyEqual(to: lastPushedSoftwareGainDB) {
             pushToProcessor()
         }
+    }
+
+    private func pushHardwareVolume(_ percent: Double) {
+        guard !Self.screenshotMode, hasHardwareVolume, let device = currentDevice else { return }
+        hardwareVolumeWriter.submit(deviceID: device.id,
+                                    volume: Float(min(percent, 100) / 100))
     }
 
     private func syncVolumeFromDevice(externalChange: Bool = false) {
@@ -498,7 +525,9 @@ final class AppState: ObservableObject {
         currentDeviceHasHardwareVolume = true
         // Preserve intentional software boost during routine refreshes. A real
         // hardware-volume event is an explicit user adjustment, so reflect it
-        // even when the UI was previously above 100%.
+        // even when the UI was previously above 100%. Assigning `volumePercent`
+        // directly marks this as an observation: it updates the UI and software
+        // gain but is never echoed back to the device.
         if externalChange || volumePercent <= 100 {
             let percent = Double(hw) * 100
             if abs(percent - volumePercent) > 0.5 {

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -124,6 +124,7 @@ final class AppState: ObservableObject {
     private var suggestedDeviceUIDs = Set(UserDefaults.standard.stringArray(forKey: "profileSuggestion.seenDeviceUIDs") ?? [])
     private var currentDeviceHasHardwareVolume = false
     private var lastPushedSoftwareGainDB = Double.nan
+    private var pendingExternalVolumeSync: DispatchWorkItem?
     private struct HardwareVolumeListener {
         let deviceID: AudioObjectID
         let address: AudioObjectPropertyAddress
@@ -329,7 +330,7 @@ final class AppState: ObservableObject {
             let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
                 Task { @MainActor in
                     guard let self, self.currentDevice?.id == deviceID else { return }
-                    self.syncVolumeFromDevice(externalChange: true)
+                    self.scheduleExternalVolumeSync()
                 }
             }
             if AudioObjectAddPropertyListenerBlock(deviceID, &address, .main, block) == noErr {
@@ -511,6 +512,28 @@ final class AppState: ObservableObject {
         guard !Self.screenshotMode, hasHardwareVolume, let device = currentDevice else { return }
         hardwareVolumeWriter.submit(deviceID: device.id,
                                     volume: Float(min(percent, 100) / 100))
+    }
+
+    /// A hardware volume-key press makes coreaudiod ramp the level and fire a
+    /// burst of change notifications — and it briefly overshoots the target by a
+    /// step before settling (e.g. 30 → 31 → 30). The overshoot is always the
+    /// *first* value reported, so publishing on the leading edge draws it as a
+    /// visible knob stutter.
+    ///
+    /// Trailing-edge throttle: the first change schedules a single read a short
+    /// window later; further notifications in that window are folded in, so we
+    /// read the *settled* value once per window rather than the overshoot. It
+    /// throttles rather than debounces (the timer is never reset), so a held key
+    /// that sweeps the volume keeps updating steadily instead of freezing until
+    /// release.
+    private func scheduleExternalVolumeSync() {
+        guard pendingExternalVolumeSync == nil else { return }
+        let work = DispatchWorkItem { [weak self] in
+            self?.pendingExternalVolumeSync = nil
+            self?.syncVolumeFromDevice(externalChange: true)
+        }
+        pendingExternalVolumeSync = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
     }
 
     private func syncVolumeFromDevice(externalChange: Bool = false) {

--- a/Sources/OnlyEQ/App/ScreenshotRenderer.swift
+++ b/Sources/OnlyEQ/App/ScreenshotRenderer.swift
@@ -20,7 +20,7 @@ enum ScreenshotRenderer {
             demo.source = "AutoEq"
             state.preset = demo
         }
-        state.volumePercent = 65
+        state.userVolumePercent = 65
 
         let dir = URL(fileURLWithPath: outputDir)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)

--- a/Sources/OnlyEQ/Audio/AudioDeviceManager.swift
+++ b/Sources/OnlyEQ/Audio/AudioDeviceManager.swift
@@ -126,6 +126,42 @@ enum AudioDeviceManager {
         return value
     }
 
+    static func tapFormat(_ id: AudioObjectID) -> AudioStreamBasicDescription? {
+        var addr = address(kAudioTapPropertyFormat)
+        var value = AudioStreamBasicDescription()
+        var size = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        guard AudioObjectGetPropertyData(id, &addr, 0, nil, &size, &value) == noErr else { return nil }
+        return value
+    }
+
+    static func inputStreamFormats(_ id: AudioObjectID) -> [AudioStreamBasicDescription]? {
+        var streamAddress = address(kAudioDevicePropertyStreams, scope: kAudioDevicePropertyScopeInput)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(id, &streamAddress, 0, nil, &size) == noErr else { return nil }
+        var streams = [AudioObjectID](repeating: 0, count: Int(size) / MemoryLayout<AudioObjectID>.size)
+        guard AudioObjectGetPropertyData(id, &streamAddress, 0, nil, &size, &streams) == noErr else { return nil }
+        var formats: [AudioStreamBasicDescription] = []
+        formats.reserveCapacity(streams.count)
+        for stream in streams {
+            var formatAddress = address(kAudioStreamPropertyVirtualFormat)
+            var format = AudioStreamBasicDescription()
+            var formatSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+            guard AudioObjectGetPropertyData(stream, &formatAddress, 0, nil, &formatSize, &format) == noErr else { return nil }
+            formats.append(format)
+        }
+        return formats
+    }
+
+    static func inputStreamChannelCounts(_ id: AudioObjectID) -> [UInt32]? {
+        var addr = address(kAudioDevicePropertyStreamConfiguration, scope: kAudioDevicePropertyScopeInput)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(id, &addr, 0, nil, &size) == noErr, size > 0 else { return nil }
+        let storage = UnsafeMutableRawPointer.allocate(byteCount: Int(size), alignment: MemoryLayout<AudioBufferList>.alignment)
+        defer { storage.deallocate() }
+        guard AudioObjectGetPropertyData(id, &addr, 0, nil, &size, storage) == noErr else { return nil }
+        return UnsafeMutableAudioBufferListPointer(storage.assumingMemoryBound(to: AudioBufferList.self)).map(\.mNumberChannels)
+    }
+
     // MARK: - Volume
 
     static func hardwareVolumeAddresses(_ id: AudioObjectID) -> [AudioObjectPropertyAddress] {

--- a/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
+++ b/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
@@ -3,6 +3,41 @@ import CoreAudio
 import AudioToolbox
 import Accelerate
 
+struct TapInputSelection: Equatable {
+    let bufferIndex: Int
+    let channels: Int
+
+    init(bufferIndex: Int, channels: Int) {
+        self.bufferIndex = bufferIndex
+        self.channels = channels
+    }
+
+    static func select(tapFormat: AudioStreamBasicDescription,
+                       aggregateInputFormats: [AudioStreamBasicDescription],
+                       aggregateInputChannels: [UInt32]) -> TapInputSelection? {
+        guard tapFormat.mFormatID == kAudioFormatLinearPCM,
+              tapFormat.mFormatFlags & kAudioFormatFlagIsFloat != 0,
+              tapFormat.mFormatFlags & kAudioFormatFlagIsNonInterleaved == 0,
+              tapFormat.mBitsPerChannel == 32,
+              tapFormat.mChannelsPerFrame == 2,
+              aggregateInputFormats.count == aggregateInputChannels.count else { return nil }
+        var matches: [TapInputSelection] = []
+        for (index, format) in aggregateInputFormats.enumerated()
+            where aggregateInputChannels[index] == 2 && compatible(format, tapFormat) {
+            matches.append(TapInputSelection(bufferIndex: index, channels: 2))
+        }
+        guard matches.count == 1 else { return nil }
+        return matches[0]
+    }
+
+    private static func compatible(_ lhs: AudioStreamBasicDescription, _ rhs: AudioStreamBasicDescription) -> Bool {
+        lhs.mSampleRate == rhs.mSampleRate && lhs.mFormatID == rhs.mFormatID && lhs.mFormatFlags == rhs.mFormatFlags
+            && lhs.mBytesPerPacket == rhs.mBytesPerPacket && lhs.mFramesPerPacket == rhs.mFramesPerPacket
+            && lhs.mBytesPerFrame == rhs.mBytesPerFrame && lhs.mChannelsPerFrame == rhs.mChannelsPerFrame
+            && lhs.mBitsPerChannel == rhs.mBitsPerChannel
+    }
+}
+
 /// System-wide EQ engine built on Core Audio process taps (macOS 14.4+).
 ///
 /// Signal path: muted global tap (silences original output) → aggregate device
@@ -46,6 +81,7 @@ final class ProcessTapEngine {
     /// Consecutive all-zero input frames, saturated at one second's worth.
     private var silentFrames = 0
     private var isSilenceGated = false
+    private var preparedInput: TapInputSelection
 
     var onStateChange: ((State) -> Void)?
 
@@ -54,10 +90,12 @@ final class ProcessTapEngine {
     /// the owner must restart the engine to stay on pitch.
     var onSampleRateChange: (() -> Void)?
 
-    init() {
+    init(preparedInput: TapInputSelection = TapInputSelection(bufferIndex: 0, channels: 2)) {
+        self.preparedInput = preparedInput
         inputChannels.reserveCapacity(8)
         activeChannels.reserveCapacity(8)
         channelScratch.reserveCapacity(8)
+        prepareScratch(channels: preparedInput.channels, frames: ioBufferFrames)
     }
 
     // MARK: - Lifecycle
@@ -133,6 +171,21 @@ final class ProcessTapEngine {
         }
         aggregateID = newAggregateID
 
+        // AudioHardware process taps do not prove provenance by stream order:
+        // adjacent mono buffers could be physical input, so only one uniquely
+        // matched interleaved stereo tap stream is accepted.
+        guard let tapFormat = AudioDeviceManager.tapFormat(tapID),
+              let inputFormats = AudioDeviceManager.inputStreamFormats(aggregateID),
+              let inputChannels = AudioDeviceManager.inputStreamChannelCounts(aggregateID),
+              let selection = TapInputSelection.select(tapFormat: tapFormat,
+                                                        aggregateInputFormats: inputFormats,
+                                                        aggregateInputChannels: inputChannels) else {
+            cleanup()
+            transition(to: .failed("Unsupported aggregate input topology: no unique tap stream."))
+            return
+        }
+        preparedInput = selection
+
         // 3. IOProc: tapped audio arrives as input, processed audio leaves as output.
         hasReceivedAudio = false
         silentFrames = 0
@@ -164,11 +217,6 @@ final class ProcessTapEngine {
 
     func stop() {
         removeSampleRateListener()
-        if let ioProcID, aggregateID != 0 {
-            AudioDeviceStop(aggregateID, ioProcID)
-            AudioDeviceDestroyIOProcID(aggregateID, ioProcID)
-        }
-        ioProcID = nil
         cleanup()
         if state != .stopped { transition(to: .stopped) }
     }
@@ -179,6 +227,11 @@ final class ProcessTapEngine {
     }
 
     private func cleanup() {
+        if let ioProcID, aggregateID != 0 {
+            AudioDeviceStop(aggregateID, ioProcID)
+            AudioDeviceDestroyIOProcID(aggregateID, ioProcID)
+        }
+        ioProcID = nil
         if aggregateID != 0 {
             AudioHardwareDestroyAggregateDevice(aggregateID)
             aggregateID = 0
@@ -257,23 +310,31 @@ final class ProcessTapEngine {
     func render(input: UnsafePointer<AudioBufferList>, output: UnsafeMutablePointer<AudioBufferList>) {
         let inputList = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: input))
         let outputList = UnsafeMutableAudioBufferListPointer(output)
-        guard inputList.count > 0, outputList.count > 0 else { return }
-
-        // Gather input channel pointers (tap side). The tap delivers Float32;
-        // buffers may be interleaved-stereo-in-one or split per channel.
-        inputChannels.removeAll(keepingCapacity: true)
-        var frameCount = Int.max
-        for buffer in inputList {
-            guard let data = buffer.mData else { continue }
-            let channelCount = max(Int(buffer.mNumberChannels), 1)
-            let frames = Int(buffer.mDataByteSize) / MemoryLayout<Float>.size / channelCount
-            let floatPtr = data.assumingMemoryBound(to: Float.self)
-            frameCount = min(frameCount, frames)
-            for ch in 0..<channelCount {
-                inputChannels.append(InputChannel(pointer: floatPtr + ch, stride: channelCount))
-            }
+        guard inputList.count > 0, outputList.count > 0 else {
+            zero(outputList)
+            return
         }
-        guard !inputChannels.isEmpty, frameCount != .max, frameCount > 0 else { return }
+        // Consume only the prepared tap stream; other aggregate inputs can be
+        // physical streams and must never influence output.
+        inputChannels.removeAll(keepingCapacity: true)
+        guard preparedInput.bufferIndex < inputList.count else { zero(outputList); return }
+        let selectedBuffer = inputList[preparedInput.bufferIndex]
+        let channels = preparedInput.channels
+        guard channels == 2, let data = selectedBuffer.mData, Int(selectedBuffer.mNumberChannels) == channels,
+              selectedBuffer.mDataByteSize % UInt32(MemoryLayout<Float>.size * channels) == 0 else { zero(outputList); return }
+        let frameCount = Int(selectedBuffer.mDataByteSize) / MemoryLayout<Float>.size / channels
+        guard frameCount > 0 else {
+            zero(outputList)
+            return
+        }
+        let floatPtr = data.assumingMemoryBound(to: Float.self)
+        for ch in 0..<channels {
+            inputChannels.append(InputChannel(pointer: floatPtr + ch, stride: channels))
+        }
+        guard inputChannels.count <= channelScratch.count, frameCount <= scratchCapacity else {
+            zero(outputList)
+            return
+        }
 
         // Inspect the exact frames/channels the renderer consumes. Scanning the
         // raw AudioBuffer storage as one contiguous vDSP vector is incorrect for
@@ -298,17 +359,12 @@ final class ProcessTapEngine {
                     processor.resetRenderState()
                     isSilenceGated = true
                 }
-                for buffer in outputList {
-                    guard let data = buffer.mData else { continue }
-                    vDSP_vclr(data.assumingMemoryBound(to: Float.self), 1,
-                              vDSP_Length(Int(buffer.mDataByteSize) / MemoryLayout<Float>.size))
-                }
+                zero(outputList)
                 return
             }
         }
 
         // De-interleave into scratch, process, then write to the output buffers.
-        prepareScratch(channels: inputChannels.count, frames: frameCount)
         activeChannels.removeAll(keepingCapacity: true)
         var zero: Float = 0
         for (index, channel) in inputChannels.enumerated() {
@@ -360,4 +416,12 @@ final class ProcessTapEngine {
     }
 
     private var scratchCapacity = 0
+
+    private func zero(_ outputList: UnsafeMutableAudioBufferListPointer) {
+        for buffer in outputList {
+            guard let data = buffer.mData else { continue }
+            vDSP_vclr(data.assumingMemoryBound(to: Float.self), 1,
+                      vDSP_Length(Int(buffer.mDataByteSize) / MemoryLayout<Float>.size))
+        }
+    }
 }

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -259,8 +259,164 @@ enum TestRunner {
         }
     }
 
+    private static func withAudioBufferList(_ buffers: [AudioBuffer], _ body: (UnsafeMutablePointer<AudioBufferList>) -> Void) {
+        let offset = MemoryLayout<AudioBufferList>.offset(of: \.mBuffers)!
+        let storage = UnsafeMutableRawPointer.allocate(byteCount: offset + buffers.count * MemoryLayout<AudioBuffer>.size,
+                                                        alignment: MemoryLayout<AudioBufferList>.alignment)
+        defer { storage.deallocate() }
+        let list = storage.assumingMemoryBound(to: AudioBufferList.self)
+        list.pointee.mNumberBuffers = UInt32(buffers.count)
+        let destination = storage.advanced(by: offset).assumingMemoryBound(to: AudioBuffer.self)
+        destination.initialize(from: buffers, count: buffers.count)
+        body(list)
+    }
+
     private static func engineRenderTests() {
         let frames = 512, channels = 2
+
+        let stereo = AudioStreamBasicDescription(mSampleRate: 48_000, mFormatID: kAudioFormatLinearPCM,
+                                                  mFormatFlags: kAudioFormatFlagIsFloat, mBytesPerPacket: 8,
+                                                  mFramesPerPacket: 1, mBytesPerFrame: 8, mChannelsPerFrame: 2,
+                                                  mBitsPerChannel: 32, mReserved: 0)
+        var physical = stereo
+        physical.mChannelsPerFrame = 4
+        physical.mBytesPerPacket = 16
+        physical.mBytesPerFrame = 16
+        var mono = stereo
+        mono.mChannelsPerFrame = 1
+        mono.mBytesPerPacket = 4
+        mono.mBytesPerFrame = 4
+        var nonInterleaved = stereo
+        nonInterleaved.mFormatFlags |= kAudioFormatFlagIsNonInterleaved
+        expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [physical, stereo], aggregateInputChannels: [4, 2]) == TapInputSelection(bufferIndex: 1, channels: 2), "tap selection finds trailing stereo stream")
+        expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [stereo, physical], aggregateInputChannels: [2, 4]) == TapInputSelection(bufferIndex: 0, channels: 2), "tap selection follows queried stream order")
+        expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [stereo], aggregateInputChannels: [2]) == TapInputSelection(bufferIndex: 0, channels: 2), "tap selection supports built-in stereo")
+        expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [physical, mono, mono], aggregateInputChannels: [4, 1, 1]) == nil, "tap selection rejects adjacent mono candidates")
+        expect(TapInputSelection.select(tapFormat: nonInterleaved, aggregateInputFormats: [nonInterleaved], aggregateInputChannels: [2]) == nil, "tap selection rejects non-interleaved tap format")
+        expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [physical], aggregateInputChannels: [4]) == nil, "tap selection rejects missing stereo stream")
+        expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [stereo, stereo], aggregateInputChannels: [2, 2]) == nil, "tap selection rejects ambiguous stereo streams")
+
+        let reversedEngine = ProcessTapEngine(preparedInput: TapInputSelection(bufferIndex: 0, channels: 2))
+        var reversedTapInput = (0..<frames).flatMap { _ in [Float(0.125), Float(-0.25)] }
+        var reversedPhysicalInput = [Float](repeating: 77, count: frames * 4)
+        var reversedOutput = [Float](repeating: 0, count: frames * 4)
+        reversedTapInput.withUnsafeMutableBufferPointer { tapBuffer in
+            reversedPhysicalInput.withUnsafeMutableBufferPointer { physicalBuffer in
+                reversedOutput.withUnsafeMutableBufferPointer { outputBuffer in
+                    withAudioBufferList([
+                        AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(tapBuffer.count * MemoryLayout<Float>.size), mData: tapBuffer.baseAddress),
+                        AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(physicalBuffer.count * MemoryLayout<Float>.size), mData: physicalBuffer.baseAddress),
+                    ]) { input in
+                        withAudioBufferList([
+                            AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(outputBuffer.count * MemoryLayout<Float>.size), mData: outputBuffer.baseAddress),
+                        ]) { output in
+                            reversedEngine.render(input: input, output: output)
+                        }
+                    }
+                }
+            }
+        }
+        expect((0..<frames).allSatisfy { frame in
+            let base = frame * 4
+            return reversedOutput[base] == 0.125 && reversedOutput[base + 1] == -0.25
+                && reversedOutput[base + 2] == 0.125 && reversedOutput[base + 3] == -0.25
+        }, "render consumes selected tap at index 0 before physical stream")
+        expect(!reversedOutput.contains(77), "reversed render never outputs physical sentinel")
+
+        let routingEngine = ProcessTapEngine(preparedInput: TapInputSelection(bufferIndex: 1, channels: 2))
+        var physicalInput = [Float](repeating: 99, count: frames * 4)
+        var tapInput = (0..<frames).flatMap { _ in [Float(0.25), Float(-0.5)] }
+        var fourChannelOutput = [Float](repeating: 0, count: frames * 4)
+        physicalInput.withUnsafeMutableBufferPointer { physicalBuffer in
+            tapInput.withUnsafeMutableBufferPointer { tapBuffer in
+                fourChannelOutput.withUnsafeMutableBufferPointer { outputBuffer in
+                    withAudioBufferList([
+                        AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(physicalBuffer.count * MemoryLayout<Float>.size), mData: physicalBuffer.baseAddress),
+                        AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(tapBuffer.count * MemoryLayout<Float>.size), mData: tapBuffer.baseAddress),
+                    ]) { input in
+                        withAudioBufferList([
+                            AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(outputBuffer.count * MemoryLayout<Float>.size), mData: outputBuffer.baseAddress),
+                        ]) { output in
+                            routingEngine.render(input: input, output: output)
+                        }
+                    }
+                }
+            }
+        }
+        expect((0..<frames).allSatisfy { frame in
+            let base = frame * 4
+            return fourChannelOutput[base] == 0.25 && fourChannelOutput[base + 1] == -0.5
+                && fourChannelOutput[base + 2] == 0.25 && fourChannelOutput[base + 3] == -0.5
+        }, "render routes only selected tap stereo as L/R/L/R")
+        expect(!fourChannelOutput.contains(99), "iD4 render never outputs physical sentinel")
+
+        var disabledOutput = [Float](repeating: 0, count: frames * 4)
+        tapInput.withUnsafeMutableBufferPointer { tapBuffer in
+            disabledOutput.withUnsafeMutableBufferPointer { outputBuffer in
+                withAudioBufferList([
+                    AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(frames * 4 * MemoryLayout<Float>.size), mData: nil),
+                    AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(tapBuffer.count * MemoryLayout<Float>.size), mData: tapBuffer.baseAddress),
+                ]) { input in
+                    withAudioBufferList([
+                        AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(outputBuffer.count * MemoryLayout<Float>.size), mData: outputBuffer.baseAddress),
+                    ]) { output in
+                        routingEngine.render(input: input, output: output)
+                    }
+                }
+            }
+        }
+        expect(disabledOutput == fourChannelOutput, "disabled physical input with null data does not affect selected tap")
+
+        let mismatchEngine = ProcessTapEngine(preparedInput: TapInputSelection(bufferIndex: 1, channels: 2))
+        var mismatchOutput = [Float](repeating: 1, count: frames * 4)
+        tapInput.withUnsafeMutableBufferPointer { tapBuffer in
+            mismatchOutput.withUnsafeMutableBufferPointer { outputBuffer in
+                withAudioBufferList([
+                    AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(frames * 4 * MemoryLayout<Float>.size), mData: nil),
+                    AudioBuffer(mNumberChannels: 1, mDataByteSize: UInt32(tapBuffer.count * MemoryLayout<Float>.size / 2), mData: tapBuffer.baseAddress),
+                ]) { input in
+                    withAudioBufferList([
+                        AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(outputBuffer.count * MemoryLayout<Float>.size), mData: outputBuffer.baseAddress),
+                    ]) { output in
+                        mismatchEngine.render(input: input, output: output)
+                    }
+                }
+            }
+        }
+        expect(mismatchOutput.allSatisfy { $0 == 0 }, "selected-buffer shape mismatch zeros output")
+
+        let nullEngine = ProcessTapEngine(preparedInput: TapInputSelection(bufferIndex: 1, channels: 2))
+        var nullOutput = [Float](repeating: 1, count: frames * 2)
+        nullOutput.withUnsafeMutableBufferPointer { outputBuffer in
+            withAudioBufferList([
+                AudioBuffer(mNumberChannels: 4, mDataByteSize: UInt32(frames * 4 * MemoryLayout<Float>.size), mData: nil),
+                AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(frames * 2 * MemoryLayout<Float>.size), mData: nil),
+            ]) { input in
+                withAudioBufferList([
+                    AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(outputBuffer.count * MemoryLayout<Float>.size), mData: outputBuffer.baseAddress),
+                ]) { output in
+                    nullEngine.render(input: input, output: output)
+                }
+            }
+        }
+        expect(nullOutput.allSatisfy { $0 == 0 }, "null selected tap buffer zeros output")
+
+        let missingEngine = ProcessTapEngine(preparedInput: TapInputSelection(bufferIndex: 2, channels: 2))
+        var missingOutput = [Float](repeating: 1, count: frames * 2)
+        tapInput.withUnsafeMutableBufferPointer { tapBuffer in
+            missingOutput.withUnsafeMutableBufferPointer { outputBuffer in
+                withAudioBufferList([
+                    AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(tapBuffer.count * MemoryLayout<Float>.size), mData: tapBuffer.baseAddress),
+                ]) { input in
+                    withAudioBufferList([
+                        AudioBuffer(mNumberChannels: 2, mDataByteSize: UInt32(outputBuffer.count * MemoryLayout<Float>.size), mData: outputBuffer.baseAddress),
+                    ]) { output in
+                        missingEngine.render(input: input, output: output)
+                    }
+                }
+            }
+        }
+        expect(missingOutput.allSatisfy { $0 == 0 }, "missing selected tap buffer zeros output")
 
         // Audio starting later in the buffer must still mark the tap as live.
         let lateEngine = ProcessTapEngine()

--- a/Sources/OnlyEQ/UI/PopoverView.swift
+++ b/Sources/OnlyEQ/UI/PopoverView.swift
@@ -104,7 +104,7 @@ struct PopoverView: View {
                     .fixedSize()
                     Spacer(minLength: 0)
                 }
-                BoostSlider(value: $state.volumePercent, maxPercent: state.maxBoostPercent)
+                BoostSlider(value: $state.userVolumePercent, maxPercent: state.maxBoostPercent)
             }
         }
     }

--- a/Sources/OnlyEQ/UI/SettingsView.swift
+++ b/Sources/OnlyEQ/UI/SettingsView.swift
@@ -302,6 +302,6 @@ struct AdvancedSettings: View {
         }
         for preset in state.store.customPresets { state.store.delete(preset) }
         state.applyFlat()
-        state.volumePercent = 100
+        state.userVolumePercent = 100
     }
 }

--- a/appcast-v2.xml
+++ b/appcast-v2.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+        <title>OnlyEQ</title>
+        <item>
+            <title>1.2.4</title>
+            <pubDate>Thu, 30 Jul 2026 17:17:52 -0700</pubDate>
+            <link>https://github.com/zollans/OnlyEQ</link>
+            <sparkle:version>20</sparkle:version>
+            <sparkle:shortVersionString>1.2.4</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
+            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.4
+
+This is a one-time manual update because OnlyEQ's automatic-update signing key changed. Install 1.2.4 from the GitHub release or with the installer command in the README. Automatic updates resume normally after 1.2.4 is installed.
+
+- Fixes a hardware-volume feedback loop that could make the output level oscillate after using volume keys or Control Center.
+- Smooths brief hardware-volume overshoot so the OnlyEQ slider no longer jitters while a key press settles.
+- Fixes silent output on multistream audio interfaces by selecting the stereo process-tap stream instead of physical input channels.
+- Safely mutes output when an aggregate device exposes an unsupported or changing input topology.
+]]></description>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.4/OnlyEQ.app.zip" length="2690420" type="application/octet-stream" sparkle:edSignature="x9Os4Kcz0IOtHDL9yY7EuNxlf4wqKs0A5ntTurWBXaObLhD1rTtWsFr2AMF8HcPeD+7MyJ4UUKk6XxvFOsp/Aw=="/>
+        </item>
+    </channel>
+</rss>

--- a/release-notes/1.2.4.md
+++ b/release-notes/1.2.4.md
@@ -1,0 +1,8 @@
+# OnlyEQ 1.2.4
+
+This is a one-time manual update because OnlyEQ's automatic-update signing key changed. Install 1.2.4 from the GitHub release or with the installer command in the README. Automatic updates resume normally after 1.2.4 is installed.
+
+- Fixes a hardware-volume feedback loop that could make the output level oscillate after using volume keys or Control Center.
+- Smooths brief hardware-volume overshoot so the OnlyEQ slider no longer jitters while a key press settles.
+- Fixes silent output on multistream audio interfaces by selecting the stereo process-tap stream instead of physical input channels.
+- Safely mutes output when an aggregate device exposes an unsupported or changing input topology.

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -25,7 +25,7 @@ if [ ! -x "$GENERATE_APPCAST" ] || [ ! -x "$GENERATE_KEYS" ]; then
 fi
 
 # Fail before the expensive build if the signing key is unavailable.
-"$GENERATE_KEYS" --account zollans.OnlyEQ -p >/dev/null
+"$GENERATE_KEYS" --account zollans.OnlyEQ.v2 -p >/dev/null
 ./scripts/build-app.sh release
 
 ARCHIVE="build/OnlyEQ.app.zip"
@@ -39,7 +39,7 @@ cp "$ARCHIVE" "$APPCAST_WORK/OnlyEQ.app.zip"
 cp "$NOTES" "$APPCAST_WORK/OnlyEQ.app.md"
 
 "$GENERATE_APPCAST" \
-    --account zollans.OnlyEQ \
+    --account zollans.OnlyEQ.v2 \
     --download-url-prefix "https://github.com/zollans/OnlyEQ/releases/download/v$VERSION/" \
     --link "https://github.com/zollans/OnlyEQ" \
     --embed-release-notes \
@@ -47,8 +47,8 @@ cp "$NOTES" "$APPCAST_WORK/OnlyEQ.app.md"
     --maximum-deltas 0 \
     "$APPCAST_WORK"
 
-cp "$APPCAST_WORK/appcast.xml" appcast.xml
+cp "$APPCAST_WORK/appcast-v2.xml" appcast-v2.xml
 
 echo "Prepared OnlyEQ $VERSION"
 echo "  Release archive: $ARCHIVE"
-echo "  Signed appcast: appcast.xml"
+echo "  Signed appcast: appcast-v2.xml"


### PR DESCRIPTION
## Summary

- includes the tested fixes from #24 and #25
- bumps OnlyEQ to 1.2.4 (build 20)
- moves future automatic updates to `appcast-v2.xml` with a newly backed-up Sparkle signing identity
- documents the one-time manual reinstall required for users on 1.2.3 and earlier

## Why

The original Sparkle Ed25519 private key is no longer available. Because existing releases are ad-hoc signed, Sparkle key rotation cannot authenticate a new key automatically. Version 1.2.4 is therefore a manual bridge release; later versions can update automatically through the v2 feed.

## Validation

- combined PR build tested locally on macOS hardware
- `swift run OnlyEQ --test` — 99 passed, 0 failed
- universal arm64 + x86_64 release build completed
- app bundle code signature verified
- release ZIP integrity verified
- Sparkle archive signature verified against the new v2 key
- generated appcast version, URL, archive length, and signature verified
- manual speaker/volume behavior test passed