### PR TITLE
Stop muted tap when audio output disappears

### DIFF
--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -349,18 +349,26 @@ final class AppState: ObservableObject {
         refreshDevices()
         let defaultDeviceID = AudioDeviceManager.defaultOutputDeviceID()
 
-        // `currentDevice` is UI state and may already have been refreshed by a
-        // device-list notification. Compare against the engine's actual route;
-        // otherwise the later default-device notification can look unchanged
-        // while audio is still attached to the disconnected output.
-        if Self.routeNeedsRebuild(
+        // A process tap with `.mutedWhenTapped` silences the original system
+        // mix. If Core Audio temporarily publishes no usable default output,
+        // keeping that tap alive can strand every app behind a route that no
+        // longer exists (web video may stall as well as going silent). Tear it
+        // down immediately, then rebuild when a complete topology returns.
+        switch Self.topologyAction(
             isEnabled: isEnabled,
+            engineIsRunning: engine.state == .running,
             engineTargetID: engine.targetDeviceID,
             defaultDeviceID: defaultDeviceID,
             defaultDeviceIsReady: currentDevice != nil
         ) {
+        case .stop:
+            Log.write("device: output unavailable; stopping muted tap")
+            engine.stop()
+        case .rebuild:
             Log.write("device: rebuilding route \(engine.targetDeviceID) -> \(defaultDeviceID ?? 0) (\(currentDevice?.name ?? "unavailable"))")
             rebuildEngine()
+        case .none:
+            break
         }
 
         if let currentDevice, previousUID != currentDevice.uid {
@@ -370,13 +378,24 @@ final class AppState: ObservableObject {
         }
     }
 
-    nonisolated static func routeNeedsRebuild(
+    enum AudioTopologyAction: Equatable {
+        case none
+        case stop
+        case rebuild
+    }
+
+    nonisolated static func topologyAction(
         isEnabled: Bool,
+        engineIsRunning: Bool,
         engineTargetID: AudioObjectID,
         defaultDeviceID: AudioObjectID?,
         defaultDeviceIsReady: Bool
-    ) -> Bool {
-        isEnabled && defaultDeviceIsReady && defaultDeviceID != engineTargetID
+    ) -> AudioTopologyAction {
+        guard isEnabled else { return .none }
+        guard let defaultDeviceID, defaultDeviceIsReady else {
+            return engineIsRunning ? .stop : .none
+        }
+        return !engineIsRunning || defaultDeviceID != engineTargetID ? .rebuild : .none
     }
 
     private func suggestProfileForCurrentDeviceIfNeeded() {

--- a/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
+++ b/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
@@ -104,6 +104,11 @@ final class ProcessTapEngine {
     /// current system default output.
     func start(outputDeviceID explicitDevice: AudioObjectID? = nil, excludedBundleIDs: Set<String> = []) {
         stop()
+        // A previous engine instance may have received audio even when this
+        // start attempt cannot resolve an output device. Reset probe state up
+        // front so failed restarts never masquerade as a live audio path.
+        hasReceivedAudio = false
+        targetDeviceID = 0
 
         guard let deviceID = explicitDevice ?? AudioDeviceManager.defaultOutputDeviceID(),
               let deviceUID = AudioDeviceManager.stringProperty(deviceID, kAudioDevicePropertyDeviceUID) else {
@@ -187,7 +192,6 @@ final class ProcessTapEngine {
         preparedInput = selection
 
         // 3. IOProc: tapped audio arrives as input, processed audio leaves as output.
-        hasReceivedAudio = false
         silentFrames = 0
         isSilenceGated = false
         status = AudioDeviceCreateIOProcIDWithBlock(&ioProcID, aggregateID, nil) { [weak self] _, inInputData, _, outOutputData, _ in
@@ -218,6 +222,8 @@ final class ProcessTapEngine {
     func stop() {
         removeSampleRateListener()
         cleanup()
+        targetDeviceID = 0
+        hasReceivedAudio = false
         if state != .stopped { transition(to: .stopped) }
     }
 

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -489,28 +489,46 @@ enum TestRunner {
         )
 
         expect(
-            AppState.routeNeedsRebuild(
-                isEnabled: true, engineTargetID: 41, defaultDeviceID: 52, defaultDeviceIsReady: true
-            ),
+            AppState.topologyAction(
+                isEnabled: true, engineIsRunning: true,
+                engineTargetID: 41, defaultDeviceID: 52, defaultDeviceIsReady: true
+            ) == .rebuild,
             "route rebuild follows engine target after UI device refresh"
         )
         expect(
-            !AppState.routeNeedsRebuild(
-                isEnabled: true, engineTargetID: 52, defaultDeviceID: 52, defaultDeviceIsReady: true
-            ),
+            AppState.topologyAction(
+                isEnabled: true, engineIsRunning: true,
+                engineTargetID: 52, defaultDeviceID: 52, defaultDeviceIsReady: true
+            ) == .none,
             "route rebuild skips matching engine target"
         )
         expect(
-            !AppState.routeNeedsRebuild(
-                isEnabled: false, engineTargetID: 41, defaultDeviceID: 52, defaultDeviceIsReady: true
-            ),
+            AppState.topologyAction(
+                isEnabled: false, engineIsRunning: true,
+                engineTargetID: 41, defaultDeviceID: 52, defaultDeviceIsReady: true
+            ) == .none,
             "disabled engine ignores route changes"
         )
         expect(
-            !AppState.routeNeedsRebuild(
-                isEnabled: true, engineTargetID: 41, defaultDeviceID: 52, defaultDeviceIsReady: false
-            ),
-            "route rebuild waits for transient device topology to settle"
+            AppState.topologyAction(
+                isEnabled: true, engineIsRunning: true,
+                engineTargetID: 41, defaultDeviceID: nil, defaultDeviceIsReady: false
+            ) == .stop,
+            "missing output tears down the muted tap"
+        )
+        expect(
+            AppState.topologyAction(
+                isEnabled: true, engineIsRunning: false,
+                engineTargetID: 0, defaultDeviceID: nil, defaultDeviceIsReady: false
+            ) == .none,
+            "missing output leaves an already stopped engine alone"
+        )
+        expect(
+            AppState.topologyAction(
+                isEnabled: true, engineIsRunning: false,
+                engineTargetID: 0, defaultDeviceID: 52, defaultDeviceIsReady: true
+            ) == .rebuild,
+            "restored output restarts a fail-safe stopped engine"
         )
 
         MainActor.assumeIsolated {


### PR DESCRIPTION
## What changed

- Tear down the active process tap immediately when Core Audio temporarily has no usable default output.
- Restart the engine once a complete output topology returns, including when the restored device has the same object ID.
- Reset `targetDeviceID` and `hasReceivedAudio` when stopping or beginning a new start attempt.
- Add regression coverage for unavailable, stopped, restored, and unchanged topology states.

## Root cause

OnlyEQ uses a global process tap with `mutedWhenTapped`. During an output-device transition, Core Audio can briefly publish no valid default output. The topology handler previously skipped a rebuild in that intermediate state but left the muted tap running. That could strand the system mix behind a missing route, resulting in no sound and stalled browser video. A later failed start could also retain stale `hasReceivedAudio` state from the previous engine instance.

## Impact

Invalid output topologies now fail open: OnlyEQ removes the muted tap instead of leaving the Mac silent, then resumes processing after Core Audio publishes a valid route.

## Validation

- `swift run OnlyEQ --test` — 101 checks passed, 0 failed
- `swift build -c release`
- Universal app bundle built and passed strict code-signature verification
- Installed patched build on macOS 26.6
- Restarted a previously wedged `coreaudiod`, launched OnlyEQ, exercised an AirPods route change, and confirmed processed audio in the engine log using a local system sound
- `system_profiler SPAudioDataType` continued to enumerate output devices after the live test
