### PR TITLE
Release OnlyEQ 1.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ swift run OnlyEQ --profile-suggestion-probe # previews Bluetooth profile discove
 swift run OnlyEQ --menu-panel-probe    # previews the arrowless menu panel
 swift run OnlyEQ --screenshots out/   # renders the README screenshots
 ./scripts/build-app.sh release        # universal binary release build
-./scripts/prepare-release.sh 1.2.4    # signed archive + v2 appcast
+./scripts/prepare-release.sh 1.2.5    # signed archive + v2 appcast
 ```
 
 Tests run inside the binary because the Command Line Tools don't ship XCTest. Diagnostics land in `~/Library/Logs/OnlyEQ.log`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,10 +15,10 @@ For each release:
 Example publishing command after the release commit is on `main`:
 
 ```sh
-gh release create v1.2.4 \
+gh release create v1.2.5 \
   build/OnlyEQ.app.zip appcast-v2.xml \
-  --title "OnlyEQ 1.2.4" \
-  --notes-file release-notes/1.2.4.md \
+  --title "OnlyEQ 1.2.5" \
+  --notes-file release-notes/1.2.5.md \
   --target main
 ```
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>20</string>
+	<string>21</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.4</string>
+	<string>1.2.5</string>
 	<key>CFBundleExecutable</key>
 	<string>OnlyEQ</string>
 	<key>CFBundlePackageType</key>

--- a/appcast-v2.xml
+++ b/appcast-v2.xml
@@ -3,22 +3,19 @@
     <channel>
         <title>OnlyEQ</title>
         <item>
-            <title>1.2.4</title>
-            <pubDate>Thu, 30 Jul 2026 17:17:52 -0700</pubDate>
+            <title>1.2.5</title>
+            <pubDate>Wed, 05 Aug 2026 20:35:01 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>20</sparkle:version>
-            <sparkle:shortVersionString>1.2.4</sparkle:shortVersionString>
+            <sparkle:version>21</sparkle:version>
+            <sparkle:shortVersionString>1.2.5</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
-            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.4
+            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.5
 
-This is a one-time manual update because OnlyEQ's automatic-update signing key changed. Install 1.2.4 from the GitHub release or with the installer command in the README. Automatic updates resume normally after 1.2.4 is installed.
-
-- Fixes a hardware-volume feedback loop that could make the output level oscillate after using volume keys or Control Center.
-- Smooths brief hardware-volume overshoot so the OnlyEQ slider no longer jitters while a key press settles.
-- Fixes silent output on multistream audio interfaces by selecting the stereo process-tap stream instead of physical input channels.
-- Safely mutes output when an aggregate device exposes an unsupported or changing input topology.
+- Tears down the muted process tap immediately when Core Audio temporarily has no usable output, preventing a device transition from muting the Mac or stalling playback.
+- Restarts processing when a complete output topology returns, including when Core Audio reuses the previous device object ID.
+- Clears stale route and audio-confirmation state whenever the engine stops or begins a new start attempt.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.4/OnlyEQ.app.zip" length="2690420" type="application/octet-stream" sparkle:edSignature="x9Os4Kcz0IOtHDL9yY7EuNxlf4wqKs0A5ntTurWBXaObLhD1rTtWsFr2AMF8HcPeD+7MyJ4UUKk6XxvFOsp/Aw=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.5/OnlyEQ.app.zip" length="2690682" type="application/octet-stream" sparkle:edSignature="iI0wymIhk8fq78TR4+fgvFPgZixUiz2J+g9EgX6BnRS59sX+hX7o+SVAuxXk90z68m36TJy/Egb3cK0oEhb9CQ=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.2.5.md
+++ b/release-notes/1.2.5.md
@@ -1,0 +1,5 @@
+# OnlyEQ 1.2.5
+
+- Tears down the muted process tap immediately when Core Audio temporarily has no usable output, preventing a device transition from muting the Mac or stalling playback.
+- Restarts processing when a complete output topology returns, including when Core Audio reuses the previous device object ID.
+- Clears stale route and audio-confirmation state whenever the engine stops or begins a new start attempt.


### PR DESCRIPTION
## Summary

- bumps OnlyEQ to 1.2.5 (build 21)
- publishes the fail-open audio-topology fix from #28
- updates the signed v2 appcast and release documentation

## Impact

OnlyEQ now tears down its muted process tap as soon as Core Audio temporarily has no usable output, preventing output transitions from muting the Mac or stalling playback. Processing resumes when a complete topology returns.

## Validation

- `swift run OnlyEQ --test` — 101 passed, 0 failed
- universal arm64 + x86_64 release build completed
- app bundle code signature verified
- release ZIP integrity verified
- Sparkle archive signature verified against the backed-up v2 key
- generated appcast version, URL, archive length, and signature verified