### PR TITLE
Release OnlyEQ 1.2.6

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>21</string>
+	<string>22</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.5</string>
+	<string>1.2.6</string>
 	<key>CFBundleExecutable</key>
 	<string>OnlyEQ</string>
 	<key>CFBundlePackageType</key>

--- a/Sources/OnlyEQ/App/AppState.swift
+++ b/Sources/OnlyEQ/App/AppState.swift
@@ -125,6 +125,7 @@ final class AppState: ObservableObject {
     private var currentDeviceHasHardwareVolume = false
     private var lastPushedSoftwareGainDB = Double.nan
     private var pendingExternalVolumeSync: DispatchWorkItem?
+    private var userIsAdjustingVolume = false
     private struct HardwareVolumeListener {
         let deviceID: AudioObjectID
         let address: AudioObjectPropertyAddress
@@ -189,11 +190,12 @@ final class AppState: ObservableObject {
         }
     }
 
-    private func pushToProcessor() {
-        let outputGainDB = softwareGainDB
+    private func pushToProcessor(outputGainDB overrideOutputGainDB: Double? = nil,
+                                 preampDB overridePreampDB: Double? = nil) {
+        let outputGainDB = overrideOutputGainDB ?? softwareGainDB
         engine.processor.update(
             bands: preset.bands,
-            preampDB: effectivePreampDB,
+            preampDB: overridePreampDB ?? effectivePreampDB,
             outputGainDB: outputGainDB,
             limiterEnabled: limiterEnabled,
             limiterCeilingDB: limiterCeilingDB,
@@ -493,6 +495,10 @@ final class AppState: ObservableObject {
     // MARK: - Volume
 
     private var softwareGainDB: Double {
+        softwareGainDB(for: volumePercent)
+    }
+
+    private func softwareGainDB(for volumePercent: Double) -> Double {
         let percent = max(volumePercent, 1)
         if hasHardwareVolume {
             return percent > 100 ? 20 * log10(percent / 100) : 0
@@ -517,6 +523,39 @@ final class AppState: ObservableObject {
             volumePercent = newValue
             pushHardwareVolume(newValue)
         }
+    }
+
+    /// Continuous controls preview volume without publishing `volumePercent`.
+    /// Publishing on every pointer or trackpad event invalidates all SwiftUI
+    /// trees that observe AppState, including alive-but-hidden windows, and can
+    /// starve the display-linked spectrum animation. The control commits the
+    /// final value through `userVolumePercent` when the interaction ends.
+    func beginVolumeAdjustment() {
+        pendingExternalVolumeSync?.cancel()
+        pendingExternalVolumeSync = nil
+        userIsAdjustingVolume = true
+    }
+
+    func previewVolumeAdjustment(_ percent: Double) {
+        guard !Self.screenshotMode else { return }
+        let outputGainDB = softwareGainDB(for: percent)
+        if !outputGainDB.isApproximatelyEqual(to: lastPushedSoftwareGainDB) {
+            pushToProcessor(outputGainDB: outputGainDB)
+        }
+        pushHardwareVolume(percent)
+    }
+
+    func endVolumeAdjustment() {
+        userIsAdjustingVolume = false
+    }
+
+    /// The editor graph deliberately excludes preamp, so previewing it directly
+    /// in the processor avoids rebuilding that graph and every other AppState
+    /// observer for each slider event. The final preset value is committed when
+    /// the drag ends.
+    func previewManualPreampDB(_ preampDB: Double) {
+        guard !Self.screenshotMode else { return }
+        pushToProcessor(preampDB: preampDB)
     }
 
     private func applySoftwareGain() {
@@ -546,7 +585,7 @@ final class AppState: ObservableObject {
     /// that sweeps the volume keeps updating steadily instead of freezing until
     /// release.
     private func scheduleExternalVolumeSync() {
-        guard pendingExternalVolumeSync == nil else { return }
+        guard !userIsAdjustingVolume, pendingExternalVolumeSync == nil else { return }
         let work = DispatchWorkItem { [weak self] in
             self?.pendingExternalVolumeSync = nil
             self?.syncVolumeFromDevice(externalChange: true)
@@ -556,6 +595,7 @@ final class AppState: ObservableObject {
     }
 
     private func syncVolumeFromDevice(externalChange: Bool = false) {
+        guard !userIsAdjustingVolume else { return }
         guard let device = currentDevice else {
             currentDeviceHasHardwareVolume = false
             return

--- a/Sources/OnlyEQ/Audio/AudioDeviceManager.swift
+++ b/Sources/OnlyEQ/Audio/AudioDeviceManager.swift
@@ -108,12 +108,21 @@ enum AudioDeviceManager {
     }
 
     static func outputChannelCount(_ id: AudioObjectID) -> Int {
-        var addr = address(kAudioDevicePropertyStreamConfiguration, scope: kAudioDevicePropertyScopeOutput)
+        channelCount(id, scope: kAudioDevicePropertyScopeOutput) ?? 0
+    }
+
+    static func inputChannelCount(_ id: AudioObjectID) -> UInt32? {
+        guard let count = channelCount(id, scope: kAudioDevicePropertyScopeInput) else { return nil }
+        return UInt32(exactly: count)
+    }
+
+    private static func channelCount(_ id: AudioObjectID, scope: AudioObjectPropertyScope) -> Int? {
+        var addr = address(kAudioDevicePropertyStreamConfiguration, scope: scope)
         var size: UInt32 = 0
-        guard AudioObjectGetPropertyDataSize(id, &addr, 0, nil, &size), size > 0 else { return 0 }
+        guard AudioObjectGetPropertyDataSize(id, &addr, 0, nil, &size), size > 0 else { return nil }
         let ptr = UnsafeMutableRawPointer.allocate(byteCount: Int(size), alignment: MemoryLayout<AudioBufferList>.alignment)
         defer { ptr.deallocate() }
-        guard AudioObjectGetPropertyData(id, &addr, 0, nil, &size, ptr) == noErr else { return 0 }
+        guard AudioObjectGetPropertyData(id, &addr, 0, nil, &size, ptr) == noErr else { return nil }
         let list = ptr.assumingMemoryBound(to: AudioBufferList.self)
         return UnsafeMutableAudioBufferListPointer(list).reduce(0) { $0 + Int($1.mNumberChannels) }
     }
@@ -135,11 +144,7 @@ enum AudioDeviceManager {
     }
 
     static func inputStreamFormats(_ id: AudioObjectID) -> [AudioStreamBasicDescription]? {
-        var streamAddress = address(kAudioDevicePropertyStreams, scope: kAudioDevicePropertyScopeInput)
-        var size: UInt32 = 0
-        guard AudioObjectGetPropertyDataSize(id, &streamAddress, 0, nil, &size) == noErr else { return nil }
-        var streams = [AudioObjectID](repeating: 0, count: Int(size) / MemoryLayout<AudioObjectID>.size)
-        guard AudioObjectGetPropertyData(id, &streamAddress, 0, nil, &size, &streams) == noErr else { return nil }
+        guard let streams = inputStreams(id) else { return nil }
         var formats: [AudioStreamBasicDescription] = []
         formats.reserveCapacity(streams.count)
         for stream in streams {
@@ -150,6 +155,35 @@ enum AudioDeviceManager {
             formats.append(format)
         }
         return formats
+    }
+
+    static func inputStreamStartingChannels(_ id: AudioObjectID) -> [UInt32]? {
+        guard let streams = inputStreams(id) else { return nil }
+        var startingChannels: [UInt32] = []
+        startingChannels.reserveCapacity(streams.count)
+        for stream in streams {
+            guard let startingChannel = uint32Property(stream, kAudioStreamPropertyStartingChannel) else { return nil }
+            startingChannels.append(startingChannel)
+        }
+        return startingChannels
+    }
+
+    private static func inputStreams(_ id: AudioObjectID) -> [AudioObjectID]? {
+        var streamAddress = address(kAudioDevicePropertyStreams, scope: kAudioDevicePropertyScopeInput)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(id, &streamAddress, 0, nil, &size) == noErr else { return nil }
+        var streams = [AudioObjectID](repeating: 0, count: Int(size) / MemoryLayout<AudioObjectID>.size)
+        guard AudioObjectGetPropertyData(id, &streamAddress, 0, nil, &size, &streams) == noErr else { return nil }
+        return streams
+    }
+
+    private static func uint32Property(_ id: AudioObjectID, _ selector: AudioObjectPropertySelector) -> UInt32? {
+        var addr = address(selector)
+        guard AudioObjectHasProperty(id, &addr) else { return nil }
+        var value: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        guard AudioObjectGetPropertyData(id, &addr, 0, nil, &size, &value) == noErr else { return nil }
+        return value
     }
 
     static func inputStreamChannelCounts(_ id: AudioObjectID) -> [UInt32]? {

--- a/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
+++ b/Sources/OnlyEQ/Audio/ProcessTapEngine.swift
@@ -14,7 +14,9 @@ struct TapInputSelection: Equatable {
 
     static func select(tapFormat: AudioStreamBasicDescription,
                        aggregateInputFormats: [AudioStreamBasicDescription],
-                       aggregateInputChannels: [UInt32]) -> TapInputSelection? {
+                       aggregateInputChannels: [UInt32],
+                       aggregateInputStartingChannels: [UInt32] = [],
+                       physicalInputChannelCount: UInt32? = nil) -> TapInputSelection? {
         guard tapFormat.mFormatID == kAudioFormatLinearPCM,
               tapFormat.mFormatFlags & kAudioFormatFlagIsFloat != 0,
               tapFormat.mFormatFlags & kAudioFormatFlagIsNonInterleaved == 0,
@@ -26,8 +28,22 @@ struct TapInputSelection: Equatable {
             where aggregateInputChannels[index] == 2 && compatible(format, tapFormat) {
             matches.append(TapInputSelection(bufferIndex: index, channels: 2))
         }
-        guard matches.count == 1 else { return nil }
-        return matches[0]
+        if matches.count == 1 { return matches[0] }
+
+        // Some interfaces expose a physical stereo input with the exact same
+        // format as the stereo process tap. In the aggregate's input channel
+        // space, the tap starts immediately after the physical device inputs.
+        // Use that channel boundary to establish provenance without assuming
+        // that Core Audio returns the streams in a particular array order.
+        guard aggregateInputStartingChannels.count == aggregateInputFormats.count,
+              let physicalInputChannelCount,
+              physicalInputChannelCount < UInt32.max else { return nil }
+        let tapStartingChannel = physicalInputChannelCount + 1
+        let boundaryMatches = matches.filter {
+            aggregateInputStartingChannels[$0.bufferIndex] == tapStartingChannel
+        }
+        guard boundaryMatches.count == 1 else { return nil }
+        return boundaryMatches[0]
     }
 
     private static func compatible(_ lhs: AudioStreamBasicDescription, _ rhs: AudioStreamBasicDescription) -> Bool {
@@ -176,15 +192,24 @@ final class ProcessTapEngine {
         }
         aggregateID = newAggregateID
 
-        // AudioHardware process taps do not prove provenance by stream order:
-        // adjacent mono buffers could be physical input, so only one uniquely
-        // matched interleaved stereo tap stream is accepted.
+        // Prefer a unique format match. If a physical stereo input has the
+        // same format as the tap, use aggregate channel numbering to identify
+        // the tap without relying on stream-array order.
         guard let tapFormat = AudioDeviceManager.tapFormat(tapID),
               let inputFormats = AudioDeviceManager.inputStreamFormats(aggregateID),
-              let inputChannels = AudioDeviceManager.inputStreamChannelCounts(aggregateID),
-              let selection = TapInputSelection.select(tapFormat: tapFormat,
-                                                        aggregateInputFormats: inputFormats,
-                                                        aggregateInputChannels: inputChannels) else {
+              let inputChannels = AudioDeviceManager.inputStreamChannelCounts(aggregateID) else {
+            cleanup()
+            transition(to: .failed("Unsupported aggregate input topology: no unique tap stream."))
+            return
+        }
+        let selection = TapInputSelection.select(
+            tapFormat: tapFormat,
+            aggregateInputFormats: inputFormats,
+            aggregateInputChannels: inputChannels,
+            aggregateInputStartingChannels: AudioDeviceManager.inputStreamStartingChannels(aggregateID) ?? [],
+            physicalInputChannelCount: AudioDeviceManager.inputChannelCount(deviceID)
+        )
+        guard let selection else {
             cleanup()
             transition(to: .failed("Unsupported aggregate input topology: no unique tap stream."))
             return

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -470,6 +470,20 @@ enum TestRunner {
 
     private static func appStateTests() {
         expect(
+            BoostSlider.valueAfterScroll(50, deltaY: 1, isPrecise: false, maxPercent: 200) == 52,
+            "volume mouse wheel uses two-percent steps"
+        )
+        expect(
+            near(BoostSlider.valueAfterScroll(50, deltaY: 5, isPrecise: true, maxPercent: 200), 51),
+            "volume trackpad scroll uses fine-grained steps"
+        )
+        expect(
+            BoostSlider.valueAfterScroll(199, deltaY: 3, isPrecise: false, maxPercent: 200) == 200
+                && BoostSlider.valueAfterScroll(1, deltaY: -3, isPrecise: false, maxPercent: 200) == 0,
+            "volume scrolling clamps to its configured range"
+        )
+
+        expect(
             !AppState.shouldSuggestAudioAccessCheck(
                 isEnabled: true,
                 engineIsRunning: true,
@@ -536,10 +550,22 @@ enum TestRunner {
             let state = AppState.shared
             let savedPreset = state.preset
             let savedAuto = state.autoPreampEnabled
+            let savedVolume = state.userVolumePercent
             defer {
                 state.preset = savedPreset
                 state.autoPreampEnabled = savedAuto
+                state.userVolumePercent = savedVolume
             }
+
+            var volumePublishes = 0
+            let volumeSubscription = state.objectWillChange.sink { _ in volumePublishes += 1 }
+            state.beginVolumeAdjustment()
+            state.previewVolumeAdjustment(min(savedVolume + 1, state.maxBoostPercent))
+            expect(volumePublishes == 0, "live volume preview does not invalidate the whole app")
+            state.userVolumePercent = min(savedVolume + 1, state.maxBoostPercent)
+            state.endVolumeAdjustment()
+            expect(volumePublishes == 1, "finished volume adjustment publishes once")
+            withExtendedLifetime(volumeSubscription) {}
 
             state.autoPreampEnabled = true
             state.preset = EQPreset(name: "Auto A", bands: [EQBand(type: .peak, frequency: 1000, gain: 5, q: 1.41)])

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -295,6 +295,24 @@ enum TestRunner {
         expect(TapInputSelection.select(tapFormat: nonInterleaved, aggregateInputFormats: [nonInterleaved], aggregateInputChannels: [2]) == nil, "tap selection rejects non-interleaved tap format")
         expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [physical], aggregateInputChannels: [4]) == nil, "tap selection rejects missing stereo stream")
         expect(TapInputSelection.select(tapFormat: stereo, aggregateInputFormats: [stereo, stereo], aggregateInputChannels: [2, 2]) == nil, "tap selection rejects ambiguous stereo streams")
+        expect(TapInputSelection.select(tapFormat: stereo,
+                                        aggregateInputFormats: [stereo, stereo],
+                                        aggregateInputChannels: [2, 2],
+                                        aggregateInputStartingChannels: [1, 3],
+                                        physicalInputChannelCount: 2) == TapInputSelection(bufferIndex: 1, channels: 2),
+               "tap selection resolves Scarlett-style matching stereo input at channel boundary")
+        expect(TapInputSelection.select(tapFormat: stereo,
+                                        aggregateInputFormats: [stereo, stereo],
+                                        aggregateInputChannels: [2, 2],
+                                        aggregateInputStartingChannels: [3, 1],
+                                        physicalInputChannelCount: 2) == TapInputSelection(bufferIndex: 0, channels: 2),
+               "tap selection uses channel provenance rather than stream-array order")
+        expect(TapInputSelection.select(tapFormat: stereo,
+                                        aggregateInputFormats: [stereo, stereo],
+                                        aggregateInputChannels: [2, 2],
+                                        aggregateInputStartingChannels: [1, 3],
+                                        physicalInputChannelCount: 4) == nil,
+               "tap selection rejects matching streams without the expected channel boundary")
 
         let reversedEngine = ProcessTapEngine(preparedInput: TapInputSelection(bufferIndex: 0, channels: 2))
         var reversedTapInput = (0..<frames).flatMap { _ in [Float(0.125), Float(-0.25)] }

--- a/Sources/OnlyEQ/UI/EQCurveView.swift
+++ b/Sources/OnlyEQ/UI/EQCurveView.swift
@@ -263,6 +263,7 @@ private final class SpectrumBarsNSView: NSView {
     private var lastAnalysisTime: CFTimeInterval = 0
     private var barOpacity = 0.10
     private var heightScale = 0.75
+    private var configuredStyle: EQCurveView.SpectrumStyle?
 
     init(spectrum: SpectrumAnalyzer) {
         self.spectrum = spectrum
@@ -278,6 +279,8 @@ private final class SpectrumBarsNSView: NSView {
     }
 
     func configure(style: EQCurveView.SpectrumStyle) {
+        guard configuredStyle != style else { return }
+        configuredStyle = style
         barOpacity = style.opacity
         heightScale = style.heightScale
         updateColors()

--- a/Sources/OnlyEQ/UI/EditorView.swift
+++ b/Sources/OnlyEQ/UI/EditorView.swift
@@ -208,17 +208,15 @@ struct EditorView: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: true, vertical: false)
                 .layoutPriority(2)
-            Text(String(format: "%.1f dB", state.effectivePreampDB))
-                .font(.system(size: 11, weight: .medium).monospacedDigit())
-                .frame(width: 52, alignment: .trailing)
-                .fixedSize(horizontal: true, vertical: false)
-                .layoutPriority(2)
-            Slider(value: Binding(
-                get: { state.preset.preampDB },
-                set: { state.preset.preampDB = ($0 * 10).rounded() / 10 }
-            ), in: -20...0)
-                .frame(minWidth: 72, idealWidth: 150, maxWidth: 160)
-                .disabled(state.autoPreampEnabled)
+            ManualPreampControl(
+                value: Binding(
+                    get: { state.preset.preampDB },
+                    set: { state.preset.preampDB = $0 }
+                ),
+                effectiveValue: state.effectivePreampDB,
+                isDisabled: state.autoPreampEnabled,
+                onPreview: { state.previewManualPreampDB($0) }
+            )
             Toggle("Auto", isOn: $state.autoPreampEnabled)
                 .toggleStyle(.checkbox)
                 .fixedSize(horizontal: true, vertical: false)
@@ -265,6 +263,49 @@ struct EditorView: View {
             }
         }
         .padding(20)
+    }
+}
+
+/// Keeps manual-preamp tracking local so the rest of the editor only observes
+/// the single committed preset change at drag end.
+private struct ManualPreampControl: View {
+    @Binding var value: Double
+    var effectiveValue: Double
+    var isDisabled: Bool
+    var onPreview: (Double) -> Void
+    @State private var trackedValue: Double?
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(String(format: "%.1f dB", trackedValue ?? effectiveValue))
+                .font(.system(size: 11, weight: .medium).monospacedDigit())
+                .frame(width: 52, alignment: .trailing)
+                .fixedSize(horizontal: true, vertical: false)
+                .layoutPriority(2)
+            Slider(
+                value: Binding(
+                    get: { trackedValue ?? value },
+                    set: { updated in
+                        let rounded = (updated * 10).rounded() / 10
+                        trackedValue = rounded
+                        onPreview(rounded)
+                    }
+                ),
+                in: -20...0,
+                onEditingChanged: { editing in
+                    if !editing { commitTrackedValue() }
+                }
+            )
+            .frame(minWidth: 72, idealWidth: 150, maxWidth: 160)
+            .disabled(isDisabled)
+        }
+        .onDisappear { commitTrackedValue() }
+    }
+
+    private func commitTrackedValue() {
+        guard let trackedValue else { return }
+        value = trackedValue
+        self.trackedValue = nil
     }
 }
 

--- a/Sources/OnlyEQ/UI/PopoverView.swift
+++ b/Sources/OnlyEQ/UI/PopoverView.swift
@@ -104,7 +104,18 @@ struct PopoverView: View {
                     .fixedSize()
                     Spacer(minLength: 0)
                 }
-                BoostSlider(value: $state.userVolumePercent, maxPercent: state.maxBoostPercent)
+                BoostSlider(
+                    value: $state.userVolumePercent,
+                    maxPercent: state.maxBoostPercent,
+                    onPreview: { state.previewVolumeAdjustment($0) },
+                    onEditingChanged: { editing in
+                        if editing {
+                            state.beginVolumeAdjustment()
+                        } else {
+                            state.endVolumeAdjustment()
+                        }
+                    }
+                )
             }
         }
     }
@@ -272,10 +283,13 @@ struct PopoverView: View {
 struct BoostSlider: View {
     @Binding var value: Double
     var maxPercent: Double
+    var onPreview: (Double) -> Void = { _ in }
+    var onEditingChanged: (_ editing: Bool) -> Void = { _ in }
     private let knobDiameter: CGFloat = 15
     @State private var trackedValue: Double?
-    @State private var lastPublishedTime: TimeInterval = 0
-    @State private var publicationInterval: TimeInterval = 1.0 / 60.0
+    @State private var lastPreviewTime: TimeInterval = 0
+    @State private var previewInterval: TimeInterval = 1.0 / 60.0
+    @State private var scrollCommit: DispatchWorkItem?
 
     var body: some View {
         let displayedValue = trackedValue ?? value
@@ -325,22 +339,26 @@ struct BoostSlider: View {
                     .gesture(DragGesture(minimumDistance: 0)
                         .onChanged { gesture in
                             let updated = sliderValue(at: gesture.location.x, width: width)
+                            beginTrackingIfNeeded(at: updated)
                             trackedValue = updated
                             let now = ProcessInfo.processInfo.systemUptime
-                            if lastPublishedTime == 0 {
-                                publicationInterval = DisplayRefreshRate.interval()
+                            if lastPreviewTime == 0 {
+                                previewInterval = DisplayRefreshRate.interval()
                             }
-                            if lastPublishedTime == 0 || now - lastPublishedTime >= publicationInterval {
-                                value = updated
-                                lastPublishedTime = now
+                            if lastPreviewTime == 0 || now - lastPreviewTime >= previewInterval {
+                                onPreview(updated)
+                                lastPreviewTime = now
                             }
                         }
                         .onEnded { gesture in
                             let updated = sliderValue(at: gesture.location.x, width: width)
-                            value = updated
-                            trackedValue = nil
-                            lastPublishedTime = 0
+                            finishTracking(at: updated)
                         })
+                    .overlay {
+                        ScrollWheelMonitor { deltaY, isPrecise in
+                            adjustFromScroll(deltaY: deltaY, isPrecise: isPrecise)
+                        }
+                    }
                 }
                 .frame(height: 18)
             }
@@ -363,6 +381,9 @@ struct BoostSlider: View {
             // above so 0%, 100%, and max stay under the actual track.
             .padding(.leading, 68)
         }
+        .onDisappear {
+            if let trackedValue { finishTracking(at: trackedValue) }
+        }
     }
 
     private func sliderValue(at x: CGFloat, width: CGFloat) -> Double {
@@ -372,6 +393,101 @@ struct BoostSlider: View {
 
     private func sliderPosition(for fraction: Double, width: CGFloat) -> CGFloat {
         knobDiameter / 2 + CGFloat(fraction) * max(width - knobDiameter, 0)
+    }
+
+    private func beginTrackingIfNeeded(at currentValue: Double) {
+        guard trackedValue == nil else { return }
+        trackedValue = currentValue
+        onEditingChanged(true)
+    }
+
+    private func finishTracking(at finalValue: Double) {
+        scrollCommit?.cancel()
+        scrollCommit = nil
+        onPreview(finalValue)
+        value = finalValue
+        trackedValue = nil
+        lastPreviewTime = 0
+        onEditingChanged(false)
+    }
+
+    private func adjustFromScroll(deltaY: CGFloat, isPrecise: Bool) {
+        let currentValue = trackedValue ?? value
+        let updated = Self.valueAfterScroll(
+            currentValue, deltaY: deltaY, isPrecise: isPrecise, maxPercent: maxPercent
+        )
+        guard updated != currentValue else { return }
+
+        beginTrackingIfNeeded(at: currentValue)
+        trackedValue = updated
+        onPreview(updated)
+
+        scrollCommit?.cancel()
+        let work = DispatchWorkItem { finishTracking(at: updated) }
+        scrollCommit = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: work)
+    }
+
+    static func valueAfterScroll(_ currentValue: Double, deltaY: CGFloat,
+                                 isPrecise: Bool, maxPercent: Double) -> Double {
+        let pointsPerUnit = isPrecise ? 0.2 : 2.0
+        return min(max(currentValue + Double(deltaY) * pointsPerUnit, 0), maxPercent)
+    }
+}
+
+/// Observes scroll-wheel events over the slider without taking hit-testing
+/// away from SwiftUI's drag gesture.
+private struct ScrollWheelMonitor: NSViewRepresentable {
+    var onScroll: (_ deltaY: CGFloat, _ isPrecise: Bool) -> Void
+
+    func makeNSView(context: Context) -> ScrollWheelMonitoringView {
+        ScrollWheelMonitoringView(onScroll: onScroll)
+    }
+
+    func updateNSView(_ view: ScrollWheelMonitoringView, context: Context) {
+        view.onScroll = onScroll
+    }
+}
+
+@MainActor
+private final class ScrollWheelMonitoringView: NSView {
+    var onScroll: (_ deltaY: CGFloat, _ isPrecise: Bool) -> Void
+    private var eventMonitor: Any?
+
+    init(onScroll: @escaping (_ deltaY: CGFloat, _ isPrecise: Bool) -> Void) {
+        self.onScroll = onScroll
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window == nil {
+            removeEventMonitor()
+        } else if eventMonitor == nil {
+            eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+                guard let self, event.window === self.window else { return event }
+                let location = self.convert(event.locationInWindow, from: nil)
+                guard self.bounds.contains(location), event.scrollingDeltaY != 0 else { return event }
+                self.onScroll(event.scrollingDeltaY, event.hasPreciseScrollingDeltas)
+                return nil
+            }
+        }
+    }
+
+    private func removeEventMonitor() {
+        guard let eventMonitor else { return }
+        NSEvent.removeMonitor(eventMonitor)
+        self.eventMonitor = nil
+    }
+
+    deinit {
+        if let eventMonitor { NSEvent.removeMonitor(eventMonitor) }
     }
 }
 

--- a/appcast-v2.xml
+++ b/appcast-v2.xml
@@ -3,19 +3,20 @@
     <channel>
         <title>OnlyEQ</title>
         <item>
-            <title>1.2.5</title>
-            <pubDate>Wed, 05 Aug 2026 20:35:01 -0700</pubDate>
+            <title>1.2.6</title>
+            <pubDate>Sat, 15 Aug 2026 16:26:49 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>21</sparkle:version>
-            <sparkle:shortVersionString>1.2.5</sparkle:shortVersionString>
+            <sparkle:version>22</sparkle:version>
+            <sparkle:shortVersionString>1.2.6</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
-            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.5
+            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.6
 
-- Tears down the muted process tap immediately when Core Audio temporarily has no usable output, preventing a device transition from muting the Mac or stalling playback.
-- Restarts processing when a complete output topology returns, including when Core Audio reuses the previous device object ID.
-- Clears stale route and audio-confirmation state whenever the engine stops or begins a new start attempt.
+- Supports stereo-input audio interfaces, including Focusrite Scarlett-style devices whose physical input and process tap expose identical stereo formats.
+- Keeps tap routing fail-safe by using Core Audio channel provenance only when format matching is ambiguous, and refusing topologies that still cannot identify one unique tap stream.
+- Keeps the spectrum, meter, and rest of the app responsive while adjusting volume or manual preamp by previewing audio changes without rebuilding every SwiftUI view.
+- Adds mouse-wheel and trackpad volume control when the pointer is over the volume slider.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.5/OnlyEQ.app.zip" length="2690682" type="application/octet-stream" sparkle:edSignature="iI0wymIhk8fq78TR4+fgvFPgZixUiz2J+g9EgX6BnRS59sX+hX7o+SVAuxXk90z68m36TJy/Egb3cK0oEhb9CQ=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.6/OnlyEQ.app.zip" length="2719632" type="application/octet-stream" sparkle:edSignature="hohnYoPy/eoXFH7eIAhh2oMfqTXaEo6yvIkS2GeUE2AJYf6B2AnJmhi5ydmQ1mnbT75YyzOickWj3o3zyuuVDw=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.2.6.md
+++ b/release-notes/1.2.6.md
@@ -1,0 +1,6 @@
+# OnlyEQ 1.2.6
+
+- Supports stereo-input audio interfaces, including Focusrite Scarlett-style devices whose physical input and process tap expose identical stereo formats.
+- Keeps tap routing fail-safe by using Core Audio channel provenance only when format matching is ambiguous, and refusing topologies that still cannot identify one unique tap stream.
+- Keeps the spectrum, meter, and rest of the app responsive while adjusting volume or manual preamp by previewing audio changes without rebuilding every SwiftUI view.
+- Adds mouse-wheel and trackpad volume control when the pointer is over the volume slider.


### PR DESCRIPTION
Ships the stereo-input interface routing fix from #30 together with the interaction performance update.

- Support ambiguous stereo-input/tap topologies using Core Audio channel provenance
- Keep routing fail-safe when provenance is incomplete
- Keep spectrum and meter animation responsive during volume and manual-preamp adjustment
- Add mouse-wheel and trackpad volume control

Verified with 109 self-checks, warnings-as-errors, AddressSanitizer, ThreadSanitizer, a signed universal release build, and Sparkle signature verification.