### PR TITLE
Release OnlyEQ 1.2.7

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.onlyeq.app</string>
 	<key>CFBundleVersion</key>
-	<string>22</string>
+	<string>23</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.6</string>
+	<string>1.2.7</string>
 	<key>CFBundleExecutable</key>
 	<string>OnlyEQ</string>
 	<key>CFBundlePackageType</key>

--- a/Sources/OnlyEQ/App/AppDelegate.swift
+++ b/Sources/OnlyEQ/App/AppDelegate.swift
@@ -10,6 +10,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var localMouseMonitor: Any?
     private var workspaceActivationObserver: NSObjectProtocol?
     private var hidePanelObserver: NSObjectProtocol?
+    private let appShortcutMonitor = AppShortcutMonitor()
     private let updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
         updaterDelegate: nil,
@@ -19,6 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         Log.write("app: didFinishLaunching")
         NSApp.setActivationPolicy(.accessory)
+        appShortcutMonitor.start()
 
         let state = AppState.shared
         state.onProfileSuggestion = { suggestion in
@@ -73,6 +75,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             DispatchQueue.main.asyncAfter(deadline: .now() + 15) { NSApp.terminate(nil) }
         }
 
+        if CommandLine.arguments.contains("--accessory-import-probe") {
+            DispatchQueue.main.async { WindowManager.shared.showEditor(importing: true) }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 30) { NSApp.terminate(nil) }
+        }
+
         HotKeyManager.shared.install()
 
         if !UserDefaults.standard.bool(forKey: "onboarded") {
@@ -87,6 +94,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             NSWorkspace.shared.notificationCenter.removeObserver(workspaceActivationObserver)
         }
         if let hidePanelObserver { NotificationCenter.default.removeObserver(hidePanelObserver) }
+        appShortcutMonitor.stop()
         AppState.shared.flushWorkingPresetPersistence()
         AppState.shared.engine.stop()
     }

--- a/Sources/OnlyEQ/App/AppShortcutMonitor.swift
+++ b/Sources/OnlyEQ/App/AppShortcutMonitor.swift
@@ -1,0 +1,69 @@
+import AppKit
+
+/// Accessory applications have no active main-menu command chain. Route
+/// standard window and editing shortcuts explicitly so OnlyEQ behaves like a
+/// normal Mac app while remaining a menu-bar accessory.
+@MainActor
+final class AppShortcutMonitor {
+    private var eventMonitor: Any?
+
+    func start() {
+        guard eventMonitor == nil else { return }
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            if Self.isCloseWindowShortcut(
+                characters: event.charactersIgnoringModifiers,
+                modifiers: event.modifierFlags
+            ) {
+                guard let window = NSApp.keyWindow ?? NSApp.mainWindow,
+                      window.styleMask.contains(.closable) else { return event }
+                window.performClose(nil)
+                return nil
+            }
+
+            guard let action = Self.editingAction(
+                characters: event.charactersIgnoringModifiers,
+                modifiers: event.modifierFlags
+            ), let responder = NSApp.keyWindow?.firstResponder ?? NSApp.mainWindow?.firstResponder,
+            responder.tryToPerform(action, with: nil) else {
+                return event
+            }
+            return nil
+        }
+    }
+
+    func stop() {
+        guard let eventMonitor else { return }
+        NSEvent.removeMonitor(eventMonitor)
+        self.eventMonitor = nil
+    }
+
+    nonisolated static func isCloseWindowShortcut(
+        characters: String?, modifiers: NSEvent.ModifierFlags
+    ) -> Bool {
+        normalizedModifiers(modifiers) == .command && characters?.lowercased() == "w"
+    }
+
+    nonisolated static func editingAction(
+        characters: String?, modifiers: NSEvent.ModifierFlags
+    ) -> Selector? {
+        let flags = normalizedModifiers(modifiers)
+        guard flags.contains(.command), !flags.contains(.option), !flags.contains(.control),
+              let character = characters?.lowercased() else { return nil }
+
+        switch (character, flags.contains(.shift)) {
+        case ("a", false): return #selector(NSText.selectAll(_:))
+        case ("x", false): return #selector(NSText.cut(_:))
+        case ("c", false): return #selector(NSText.copy(_:))
+        case ("v", false): return #selector(NSText.paste(_:))
+        case ("z", false): return Selector(("undo:"))
+        case ("z", true): return Selector(("redo:"))
+        default: return nil
+        }
+    }
+
+    private nonisolated static func normalizedModifiers(
+        _ modifiers: NSEvent.ModifierFlags
+    ) -> NSEvent.ModifierFlags {
+        modifiers.intersection([.command, .shift, .option, .control])
+    }
+}

--- a/Sources/OnlyEQ/TestRunner.swift
+++ b/Sources/OnlyEQ/TestRunner.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Combine
 import CoreAudio
 import Foundation
@@ -26,6 +27,7 @@ enum TestRunner {
     static func run() -> Int32 {
         do {
             try importerTests()
+            textEditingShortcutTests()
             dspTests()
             watchdogTests()
             engineRenderTests()
@@ -37,6 +39,37 @@ enum TestRunner {
         print("\(passed) checks passed, \(failures.count) failed")
         for f in failures { print("  FAIL: \(f)") }
         return failures.isEmpty ? 0 : 1
+    }
+
+    private static func textEditingShortcutTests() {
+        final class PasteProbeTextView: NSTextView {
+            var receivedPaste = false
+
+            override func paste(_ sender: Any?) {
+                receivedPaste = true
+            }
+        }
+
+        let command: NSEvent.ModifierFlags = .command
+        expect(AppShortcutMonitor.editingAction(characters: "a", modifiers: command)
+               == #selector(NSText.selectAll(_:)), "Command-A maps to Select All")
+        expect(AppShortcutMonitor.editingAction(characters: "v", modifiers: command)
+               == #selector(NSText.paste(_:)), "Command-V maps to Paste")
+        expect(AppShortcutMonitor.editingAction(characters: "z", modifiers: [.command, .shift])
+               == Selector(("redo:")), "Command-Shift-Z maps to Redo")
+        expect(AppShortcutMonitor.editingAction(characters: "v", modifiers: [.command, .option]) == nil,
+               "modified Command-V is not intercepted")
+        expect(AppShortcutMonitor.editingAction(characters: "v", modifiers: []) == nil,
+               "plain V is not intercepted")
+        expect(AppShortcutMonitor.isCloseWindowShortcut(characters: "w", modifiers: command),
+               "Command-W maps to Close Window")
+        expect(!AppShortcutMonitor.isCloseWindowShortcut(characters: "w", modifiers: [.command, .shift]),
+               "modified Command-W is not intercepted")
+
+        let textView = PasteProbeTextView()
+        let action = AppShortcutMonitor.editingAction(characters: "v", modifiers: command)
+        let delivered = action.map { textView.tryToPerform($0, with: nil) } ?? false
+        expect(delivered && textView.receivedPaste, "Paste selector is handled by a text responder")
     }
 
     private static func importerTests() throws {

--- a/Sources/OnlyEQ/UI/EditorView.swift
+++ b/Sources/OnlyEQ/UI/EditorView.swift
@@ -72,6 +72,7 @@ struct EditorView: View {
             } label: {
                 Image(systemName: "square.and.arrow.down.on.square")
             }
+            .keyboardShortcut("s", modifiers: .command)
             .help("Save as preset")
 
             Spacer()

--- a/Sources/OnlyEQ/UI/ImportSheet.swift
+++ b/Sources/OnlyEQ/UI/ImportSheet.swift
@@ -149,13 +149,22 @@ struct ImportSheet: View {
                             .allowsHitTesting(false)
                     }
                 }
-                .onChange(of: pastedText) { _, text in
-                    guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                .task(id: pastedText) {
+                    let text = pastedText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !text.isEmpty else {
                         staged = nil
                         errorMessage = nil
                         return
                     }
-                    stage(silent: true) { try PresetImporter.importText(text) }
+
+                    // Let multi-line paste and ordinary typing settle before
+                    // parsing. A new edit automatically cancels this task.
+                    do {
+                        try await Task.sleep(for: .milliseconds(250))
+                    } catch {
+                        return
+                    }
+                    stage { try PresetImporter.importText(text) }
                 }
             stagedPreview
         }
@@ -348,6 +357,7 @@ struct ImportSheet: View {
                         dismiss()
                     }
                 }
+                .keyboardShortcut("s", modifiers: .command)
             }
             Spacer()
             Button("Cancel") { dismiss() }

--- a/Sources/OnlyEQ/main.swift
+++ b/Sources/OnlyEQ/main.swift
@@ -77,7 +77,8 @@ if CommandLine.arguments.contains("--engine-probe") {
 }
 
 MainActor.assumeIsolated {
-    if CommandLine.arguments.contains("--menu-panel-probe") {
+    if CommandLine.arguments.contains("--menu-panel-probe")
+        || CommandLine.arguments.contains("--accessory-import-probe") {
         AppState.screenshotMode = true
     }
     let app = NSApplication.shared

--- a/appcast-v2.xml
+++ b/appcast-v2.xml
@@ -3,20 +3,19 @@
     <channel>
         <title>OnlyEQ</title>
         <item>
-            <title>1.2.6</title>
-            <pubDate>Sat, 15 Aug 2026 16:26:49 -0700</pubDate>
+            <title>1.2.7</title>
+            <pubDate>Wed, 19 Aug 2026 19:40:33 -0700</pubDate>
             <link>https://github.com/zollans/OnlyEQ</link>
-            <sparkle:version>22</sparkle:version>
-            <sparkle:shortVersionString>1.2.6</sparkle:shortVersionString>
+            <sparkle:version>23</sparkle:version>
+            <sparkle:shortVersionString>1.2.7</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.4</sparkle:minimumSystemVersion>
-            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.6
+            <description sparkle:format="markdown"><![CDATA[# OnlyEQ 1.2.7
 
-- Supports stereo-input audio interfaces, including Focusrite Scarlett-style devices whose physical input and process tap expose identical stereo formats.
-- Keeps tap routing fail-safe by using Core Audio channel provenance only when format matching is ambiguous, and refusing topologies that still cannot identify one unique tap stream.
-- Keeps the spectrum, meter, and rest of the app responsive while adjusting volume or manual preamp by previewing audio changes without rebuilding every SwiftUI view.
-- Adds mouse-wheel and trackpad volume control when the pointer is over the volume slider.
+- Restores Command-A, Command-C, Command-V, Command-X, and undo/redo in text fields while OnlyEQ runs as a menu-bar accessory.
+- Adds Command-S for visible “Save as preset” actions and Command-W for closing the active OnlyEQ window.
+- Shows a clear format error after pasted EQ text cannot be recognized instead of silently doing nothing.
 ]]></description>
-            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.6/OnlyEQ.app.zip" length="2719632" type="application/octet-stream" sparkle:edSignature="hohnYoPy/eoXFH7eIAhh2oMfqTXaEo6yvIkS2GeUE2AJYf6B2AnJmhi5ydmQ1mnbT75YyzOickWj3o3zyuuVDw=="/>
+            <enclosure url="https://github.com/zollans/OnlyEQ/releases/download/v1.2.7/OnlyEQ.app.zip" length="2742855" type="application/octet-stream" sparkle:edSignature="dLf1+yYJLsk8if3RN8V/8OUAd5ZfVFULgKmsf9Qfi/LHcdeFVd7tiw4640/O0iIyDygAkrCo1qABG2NcYvzaBg=="/>
         </item>
     </channel>
 </rss>

--- a/release-notes/1.2.7.md
+++ b/release-notes/1.2.7.md
@@ -1,0 +1,5 @@
+# OnlyEQ 1.2.7
+
+- Restores Command-A, Command-C, Command-V, Command-X, and undo/redo in text fields while OnlyEQ runs as a menu-bar accessory.
+- Adds Command-S for visible “Save as preset” actions and Command-W for closing the active OnlyEQ window.
+- Shows a clear format error after pasted EQ text cannot be recognized instead of silently doing nothing.


### PR DESCRIPTION
# OnlyEQ 1.2.7

- Restores Command-A, Command-C, Command-V, Command-X, and undo/redo in text fields while OnlyEQ runs as a menu-bar accessory.
- Adds Command-S for visible “Save as preset” actions and Command-W for closing the active OnlyEQ window.
- Shows a clear format error after pasted EQ text cannot be recognized instead of silently doing nothing.
